### PR TITLE
Revert "Include platform-core tests in test-regression"

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
     "test": "echo 'No unit tests implemented'",
     "test-int": "stripes test nightmare stripes.config.js",
-    "test-regression": "stripes test nightmare stripes.config.js --run WD/platform-core/checkout/users/inventory/requests/circulation/organization",
+    "test-regression": "stripes test nightmare stripes.config.js --run WD/checkout/users/inventory/requests/circulation/organization",
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^2.0.0",
-    "@folio/stripes-cli": "^1.4.0",
+    "@folio/stripes-cli": "^1.2.0",
     "eslint": "^4.19.1",
     "lodash": "^4.17.5"
   }


### PR DESCRIPTION
Reverts folio-org/platform-complete#2.   Will wait until stripes-cli v1.4.0 is released before merging