### PR TITLE
FOLIO-1549 Stripes framework 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
 # Change history for platform-complete
 
-## 1.0.0 (IN PROGRESS)
+## [1.1.0] (IN PROGRESS)
+* Upgrade platform and modules to versions targeting stripes framework 1.0, FOLIO-1549
+
+
+## 1.0.0
+* Initial platform

--- a/package.json
+++ b/package.json
@@ -14,21 +14,16 @@
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {
-    "@folio/calendar": "~2.0.4",
-    "@folio/eholdings": "~1.0.0",
-    "@folio/finance": "~1.0.0",
-    "@folio/platform-core": "~1.0.9",
-    "@folio/stripes-components": "~3.1.0",
-    "@folio/stripes-core": "~2.12.0",
-    "@folio/vendors": "~1.0.1"
-  },
-  "resolutions": {
-    "@folio/stripes-core": "~2.12.0",
-    "@folio/stripes-smart-components": "~1.7.3"
+    "@folio/eholdings": "~1.1.0",
+    "@folio/finance": "~1.1.0",
+    "@folio/platform-core": "~1.1.0",
+    "@folio/stripes": "~1.0.0",
+    "@folio/vendors": "~1.1.0",
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^2.0.0",
-    "@folio/stripes-cli": "^1.4.0",
+    "@folio/stripes-cli": "^1.5.0",
     "eslint": "^4.19.1",
     "lodash": "^4.17.5"
   }

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -3,7 +3,7 @@ const { merge } = require('lodash');
 
 const platformComplete = {
   modules: {
-    '@folio/calendar' : {},
+    // '@folio/calendar' : {},
     '@folio/eholdings' : {},
     '@folio/finance' : {},
     '@folio/vendors' : {}


### PR DESCRIPTION
This upgrades platform-complete to use stripes-framework v1.0.0. With the exception of ui-calendar, modules have been updated to their respective versions supporting stripes framework as well. See FOLIO-1549