### PR TITLE
Re-add calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {
+    "@folio/calendar": "~2.0.5",
     "@folio/eholdings": "~1.1.0",
     "@folio/finance": "~1.1.0",
     "@folio/platform-core": "~1.1.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -3,7 +3,7 @@ const { merge } = require('lodash');
 
 const platformComplete = {
   modules: {
-    // '@folio/calendar' : {},
+    '@folio/calendar' : {},
     '@folio/eholdings' : {},
     '@folio/finance' : {},
     '@folio/vendors' : {}


### PR DESCRIPTION
After updates to build/publish process for its `react-big-calendar` dependency, `ui-calendar` is ready to be re-admitted to `platform-complete`. This PR will correspond with an additional PR to the `snapshot` branch.