### PR TITLE
include platforms as devDeps to avoid hoisting trouble

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.10.0",
+    "@folio/platform-core": ">=1.3.1-SNAPSHOT",
+    "@folio/platform-erm": ">=2.2.2-SNAPSHOT",
     "eslint": "^4.19.1",
     "lodash": "^4.17.5"
   }

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -27,7 +27,6 @@ const platformComplete = {
     '@folio/plugin-find-license': {},
     '@folio/plugin-find-organization' : {},
     '@folio/plugin-find-user' : {},
-    '@folio/plugin-find-vendor': {},
     '@folio/requests' : {},
     '@folio/search' : {},
     '@folio/servicepoints' : {},


### PR DESCRIPTION
I saw it today at the CI server
A ball of yarn in its hand
I knew it would try to please semver
package dev deps out on the lam

No you can't always build what you want
You can't always build what you want
You can't always build what you want
But if you try sometimes you find
You can build what you need

I added platform-core to the json file
And added ERM for to use
Those dev-deps let "yarn build" run awhile
If they weren't there, gonna catch some abuse

I vi'ed that config file
To kill that find-vendor line
Vendors, they're organizations
And man, we can find them just fine
I decided that I would try a yarn build
My favorite compiler, node js
It built me this: a brand new lock file
Yeah, and I said one word out loud, and that was, "YES!"

Refs [STCOR-360](https://issues.folio.org/browse/STCOR-360)