### PR TITLE
FOLIO-2018 replace ui-organization with ui-tenant-settings on snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FOLIO complete platform
 
 
-Copyright (C) 2015-2018 The Open Library Foundation
+Copyright (C) 2015-2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@folio/myprofile": ">=1.1.0",
     "@folio/notes": ">=1.0.0",
     "@folio/orders": ">=1.1.0",
-    "@folio/organization": ">=2.5.1",
     "@folio/organizations": ">=1.0.0",
     "@folio/plugin-create-item": ">=1.0.0",
     "@folio/plugin-find-agreement": ">=2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
     "test": "echo 'No unit tests implemented'",
     "test-int": "stripes test nightmare stripes.config.js",
-    "test-regression": "stripes test nightmare stripes.config.js --run WD/platform-core/checkout/users/inventory/requests/circulation/organization",
+    "test-regression": "stripes test nightmare stripes.config.js --run WD/platform-core/checkout/users/inventory/requests/circulation/tenant-settings",
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -26,7 +26,6 @@ module.exports = {
     '@folio/myprofile' : {},
     '@folio/notes' : {},
     '@folio/orders' : {},
-    '@folio/organization' : {},
     '@folio/organizations' : {},
     '@folio/plugin-create-item' : {},
     '@folio/plugin-find-agreement' : {},


### PR DESCRIPTION
The ui-tenant-settings was already added in parallel.