### PR TITLE
FOLIO-1938 remove old ui-vendors from snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
-    "@folio/vendors": ">=1.3.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-redux": "^5.1.1",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -42,8 +42,7 @@ module.exports = {
     '@folio/stripes-erm-components' : {},
     '@folio/tags' : {},
     '@folio/tenant-settings' : {},
-    '@folio/users' : {},
-    '@folio/vendors': {}
+    '@folio/users' : {}
   },
 
   branding: {


### PR DESCRIPTION
Remove old ui-vendors FOLIO-1938
The replacement renamed to ui-organizations has already been here in parallel.
And see [FOLIO-2014](https://issues.folio.org/browse/FOLIO-2014)