### PR TITLE
use more conservative ~ dep on react

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
+    "react": "~16.8.6",
+    "react-dom": "~16.8.6",
     "react-redux": "^5.1.1",
     "redux": "^3.7.2"
   },


### PR DESCRIPTION
stripes and the platform both have a hard dep on react but not with the
same restriction; the platform uses `^` and stripes  `~`. Probably we
only want a hard dep in one place. Until that's resolved, we need to at
least use a consistent dependency so we don't get multiple versions of
React in the build when different versions satisfy the different
dependencies (as when 16.9 was released, which is permitted by ^16.8 but
not by ~16.8).

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678)