### PR TITLE
STCOM-581 provide react-router as a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "react": "~16.8.6",
     "react-dom": "~16.8.6",
     "react-redux": "^5.1.1",
+    "react-router": "^5.0.1",
+    "react-router-dom": "^5.0.1",
     "redux": "^3.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`react-router` and `react-router-dom` need to be provided by the platform as
dependencies for the platform's constituent modules to consume as
peerDependencies in order to guarantee that all modules are on the same
version. Modules may pass `<Link>` instances across module borders so we
need to be certain all modules agree on the same version of `<Link>` in
order to avoid crashing React.

Refs [STCOM-581](https://issues.folio.org/browse/STCOM-581)