### PR TITLE
FOLIO-2332 lock svgo to v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "@folio/stripes-cli": "^1.10.0",
     "eslint": "^4.19.1",
     "lodash": "^4.17.5"
+  },
+  "resolutions": {
+    "svgo": "1.3.0"
   }
 }


### PR DESCRIPTION
Somebody gave svgo five infinity stones and it's using them to
destory the web in v1.3.1. Luckily, I have the time stone so we
can pin ourselves in the happier times of v1.3.0.

Props to @Yurii-Danylenko for diagnosing the issue.

Refs [FOLIO-2332](https://issues.folio.org/browse/FOLIO-2332)