### PR TITLE
UIIN-875 UIIN-878 lock final-form libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,9 @@
     "@folio/stripes-cli": "^1.10.0",
     "eslint": "^4.19.1",
     "lodash": "^4.17.5"
+  },
+  "resolutions": {
+    "final-form": "4.18.5",
+    "react-final-form": "6.3.0"
   }
 }


### PR DESCRIPTION
Recent updates in final-form (v4.18.6) and react-final-form (v6.3.1)
caused a lot of grief for us. From what I can tell, the handling of
`initialValues` changed dramatically. This PR locks those libraries
at v4.18.5 and v6.3.0, respectively.

Our initial patch for UIIN-875 involved provided an empty object where
none was previously required. That solved one problem but created
another: because the form now always receives an empty object on its
first render, its props _always_ change on subsequent renders when
editing existing objects and this happens to cause problems with the
barcode-validator.

There, an optimization makes an API call only if the current value is
different than the initial value. Because that initial value is now
always defined (and always empty), the API call happens when it should
not and validation fails. Granted, the validation API request could be
more robust here and should include the item-id when available. That
would be another way to avoid this failure, though it would negate the
optimization.

Refs [UIIN-875](https://issues.folio.org/browse/UIIN-875), [UIIN-878](https://issues.folio.org/browse/UIIN-878)