### PR TITLE
revert ui-inventory to v1.13.0

### DIFF
--- a/install.json
+++ b/install.json
@@ -2,7 +2,7 @@
   "id" : "mod-orders-storage-9.0.0",
   "action" : "enable"
 }, {
-  "id" : "mod-configuration-5.2.0",
+  "id" : "mod-configuration-5.3.0",
   "action" : "enable"
 }, {
   "id" : "mod-inventory-storage-18.1.0",
@@ -113,13 +113,13 @@
   "id" : "folio_finance-1.7.1",
   "action" : "enable"
 }, {
-  "id" : "folio_inventory-1.13.1",
+  "id" : "folio_inventory-1.13.0",
   "action" : "enable"
 }, {
   "id" : "mod-invoice-storage-3.0.0",
   "action" : "enable"
 }, {
-  "id" : "mod-invoice-3.0.0",
+  "id" : "mod-invoice-3.0.1",
   "action" : "enable"
 }, {
   "id" : "folio_invoice-1.2.1",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -4,7 +4,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-configuration-5.2.0",
+    "id": "mod-configuration-5.3.0",
     "action": "enable"
   },
   {
@@ -112,7 +112,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-invoice-3.0.0",
+    "id": "mod-invoice-3.0.1",
     "action": "enable"
   },
   {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@folio/eholdings": "2.1.0",
     "@folio/erm-usage": "2.5.1",
     "@folio/finance": "1.7.1",
-    "@folio/inventory": "1.13.1",
+    "@folio/inventory": "1.13.0",
     "@folio/invoice": "1.2.1",
     "@folio/licenses": "3.6.0",
     "@folio/local-kb-admin": "1.2.0",

--- a/stripes-install.json
+++ b/stripes-install.json
@@ -44,7 +44,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_inventory-1.13.1",
+    "id": "folio_inventory-1.13.0",
     "action": "enable"
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,7 +535,28 @@
     react-intl "^2.4.0"
     redux-form "^7.4.2"
 
-"@folio/inventory@1.13.1", "@folio/inventory@^1.10.0":
+"@folio/inventory@1.13.0":
+  version "1.13.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/inventory/-/inventory-1.13.0.tgz#46234e65c0aaf0fb0fffbcdf4da5bebb76cf2bdc"
+  integrity sha512-1QjlMKQczYSlj+wH4OELIhQcyd4C0ZW0mAMBNODFMflLS0cesB5Dx2P1HqyR5LIv0341JAm5kjzbBq0TTYIvsw==
+  dependencies:
+    "@folio/react-intl-safe-html" "^1.0.2"
+    "@folio/stripes-util" "^1.6.0"
+    final-form "^4.18.2"
+    final-form-arrays "^3.0.1"
+    lodash "^4.17.4"
+    prop-types "^15.5.10"
+    query-string "^5.0.0"
+    react-copy-to-clipboard "^5.0.1"
+    react-final-form "^6.3.0"
+    react-final-form-arrays "^3.1.0"
+    react-final-form-listeners "^1.0.2"
+    react-hot-loader "^4.3.12"
+    react-intl "^2.3.0"
+    react-router-prop-types "^1.0.4"
+    redux-form "^7.0.3"
+
+"@folio/inventory@^1.10.0":
   version "1.13.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/inventory/-/inventory-1.13.1.tgz#83e53fe8b11d4e47f4c0240b749465a831db7be7"
   integrity sha512-FIJaVctdVUmgSFTg3IafK4ZvQBRWidM/TVd5ZjqAvcAvtj+B0Iz1ITePfxcAWUbHNfqyJHVSxJvc7W+D43K5pg==
@@ -1129,9 +1150,9 @@
     nightmare "^3.0.2"
 
 "@folio/stripes-util@^1.6.0", "@folio/stripes-util@~1.6.1":
-  version "1.6.1"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-1.6.1.tgz#33c71c6315b5cda921d84019206b8b3e31b541c8"
-  integrity sha512-07+/8Prck4KioNdwqL9dViiAtEEfoyZt+ZnIW2mikEe6W+NhtUw8jhne1VvT9lUdCZfQWXqpGSmBZ3eNLDXecg==
+  version "1.6.2"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-util/-/stripes-util-1.6.2.tgz#ab504118c75441ab1802a19444f453160d7fd4b3"
+  integrity sha512-Yu6wm3KHdczRlix0KVAgQW2TjTZUIAsfzex6bLuvUu22vxGLA1/pMGdekBKTyhURPyU3AuA4qy8eXFPKbdlh1A==
   dependencies:
     json2csv "^4.2.1"
     lodash "^4.17.4"
@@ -1455,9 +1476,9 @@
   integrity sha512-8bskLEkiDvuZztnfGN+vM56q2HQV8dyXS/Eb0nhXPx6fonii3hQLxfNVA2r5NTMbvEkwDo59bAau3idUXaGvww==
 
 "@types/node@>=6":
-  version "12.12.20"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-12.12.20.tgz#7b693038ce661fe57a7ffa4679440b5e7c5e8b99"
-  integrity sha512-VAe+DiwpnC/g448uN+/3gRl4th0BTdrR9gSLIOHA+SUQskaYZQDOHG7xmjiE7JUhjbXnbXytf6Ih+/pA6CtMFQ==
+  version "12.12.21"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-12.12.21.tgz#aa44a6363291c7037111c47e4661ad210aded23f"
+  integrity sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==
 
 "@types/node@^8.0.24":
   version "8.10.59"


### PR DESCRIPTION
ui-inventory `v1.13.1` contains changes that are not targeted at 2019-q4
and therefore should not be part of this release. `v1.13.1` was never
deployed to the test environment (bugfest) and therefore never tested
for 2019-q4, and can therefore be safely removed.