### PR TITLE
STRIPES-664 unlock final-form resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,6 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "final-form": "4.18.5",
-    "react-final-form": "6.3.0",
     "rxjs": "^5.4.3"
   }
 }


### PR DESCRIPTION
We could have unlocked these resolutions months ago when
@aditya-matukumalli debugged this as a problem with `initialValues` and
merged folio-org/stripes-final-form/pull/19.

Refs [STRIPES-664](https://issues.folio.org/browse/STRIPES-664)