### PR TITLE
FOLIO-2512 Add mod-ncip edge-ncip to install-extras.json

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -24,6 +24,14 @@
     "action": "enable"
   },
   {
+    "id": "mod-ncip-1.0.0",
+    "action": "enable"
+  },
+  {
+    "id": "edge-ncip-1.0.0",
+    "action": "enable"
+  },
+  {
     "id": "mod-rtac-1.3.0",
     "action": "enable"
   },


### PR DESCRIPTION
These are not included via UI modules, so adding to install-extras.json file.