### PR TITLE
STRIPES-677: Lock the version of moment because of its latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "rxjs": "^5.4.3"
+    "rxjs": "^5.4.3",
+    "moment": "2.24.0"
   }
 }


### PR DESCRIPTION
## Purpose

Built UI with fresh changes and got a *Critical dependency: the request of a dependency is an expression* error because of the moment in the browser because of new *moment* version release. There is an [issue](https://github.com/moment/moment/issues/5489) filed already in moment repo. Locking the versions on the platform level should fix the issue.