### PR TITLE
STRIPES-635 -678 provide moment v2.24 to peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
+    "moment": "~2.24.0",
     "react": "~16.12.0",
     "react-dom": "~16.12.0",
     "react-intl": "^2.9.0",
@@ -76,6 +77,6 @@
   },
   "resolutions": {
     "rxjs": "^5.4.3",
-    "moment": "2.24.0" 
+    "moment": "~2.24.0"
   }
 }


### PR DESCRIPTION
Provide a direct dep on `moment` `~2.24.0` so other repositories may
depend on it as a peer. Because we configure moment with the current
locale, it is important that all modules receive that same instance.

Refs [STRIPES-635](https://issues.folio.org/browse/STRIPES-635), [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)