### PR TITLE
update stripes-erm-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^4.0.0",
     "@folio/stripes-acq-components": "^2.0.0",
-    "@folio/stripes-erm-components": "^2.0.0",
+    "@folio/stripes-erm-components": "^3.0.0",
     "@folio/stripes-data-transfer-components": "^1.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",


### PR DESCRIPTION
`stripes-erm-components` `3.0` is required for compatibility with
`stripes` `4.0` and `react-intl` `4.5`.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)