### PR TITLE
avoid buggy react-intl 4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "moment": "~2.25.3",
     "react": "~16.13.1",
     "react-dom": "~16.13.1",
-    "react-intl": "^4.5.3",
+    "react-intl": "~4.6.10",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "moment": "~2.25.3",
     "react": "~16.13.1",
     "react-dom": "~16.13.1",
-    "react-intl": "~4.6.10",
+    "react-intl": "^4.7.2",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
Move `react-intl` from `^4.5` to `^4.7.2` to avoid the broken `4.7.1` release,
https://github.com/formatjs/formatjs/issues/1744.