### PR TITLE
Ensure minimist is at least v1.2.3 in dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "resolutions": {
     "rxjs": "^5.4.3",
+    "minimist": "^1.2.3",
     "moment": "2.25.3"
   }
 }


### PR DESCRIPTION
because of prototype pollution security issue. See here for more info: https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764