### PR TITLE
Remove stripes-data-transfer-components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^5.0.0",
     "@folio/stripes-erm-components": "^4.0.0",
-    "@folio/stripes-data-transfer-components": ">=1.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -53,7 +53,6 @@ module.exports = {
     '@folio/search' : {},
     '@folio/servicepoints' : {},
     '@folio/stripes-erm-components' : {},
-    '@folio/stripes-data-transfer-components' : {},
     '@folio/tags' : {},
     '@folio/tenant-settings' : {},
     '@folio/users' : {}


### PR DESCRIPTION
## Purpose

Remove `stripes-data-transfer-components` dependency in advance of [`stipesDeps` approach](https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#the-package-file-stripes-entry).