### PR TITLE
Add ui-plugin-create-inventory-records to the list of dependencies and modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.
+* Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@folio/oai-pmh": ">=1.0.0",
     "@folio/orders": ">=1.1.0",
     "@folio/organizations": ">=1.0.0",
+    "@folio/plugin-create-inventory-records": ">=1.0.0",
     "@folio/plugin-create-item": ">=1.0.0",
     "@folio/plugin-find-agreement": ">=2.0.0",
     "@folio/plugin-find-contact": ">=1.0.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -36,6 +36,7 @@ module.exports = {
     '@folio/oai-pmh' : {},
     '@folio/orders' : {},
     '@folio/organizations' : {},
+    '@folio/plugin-create-inventory-records' : {},
     '@folio/plugin-create-item' : {},
     '@folio/plugin-find-agreement' : {},
     '@folio/plugin-find-erm-usage-data-provider' : {},


### PR DESCRIPTION
This PR includes https://github.com/folio-org/ui-plugin-create-inventory-records to the list of dependencies so it it can show up under `folio-snapshot` and `folio-testing`