### PR TITLE
FOLIO-2738 temporarily disable courses

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@folio/checkout": ">=1.3.0",
     "@folio/circulation": ">=1.3.0",
     "@folio/circulation-log": ">=1.0.0",
-    "@folio/courses": ">=1.0.0",
     "@folio/data-export": ">=1.0.0",
     "@folio/data-import": ">=0.0.0",
     "@folio/developer": ">=1.5.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -18,7 +18,6 @@ module.exports = {
     '@folio/checkout' : {},
     '@folio/circulation' : {},
     '@folio/circulation-log' : {},
-    '@folio/courses' : {},
     '@folio/data-import' : {},
     '@folio/data-export' : {},
     '@folio/developer' : {},


### PR DESCRIPTION
Tenant activation for mod-courses is failing, preventing all reference
builds using the platform-complete environment from building
successfully. This PR removes ui-courses, in order to prevent
mod-courses from being included in the build. It is anticipated that
this PR will soon be reverted as soon as the mod-courses activation
issue is resolved.

Refs [FOLIO-2738](https://issues.folio.org/browse/FOLIO-2738)