### PR TITLE
FOLIO-2781 Re-add missing extra modules

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -44,6 +44,10 @@
     "action": "enable"
   },
   {
+    "id": "mod-graphql",
+    "action": "enable"
+  },
+  {
     "id": "mod-ncip",
     "action": "enable"
   },


### PR DESCRIPTION
Compared the old configuration at folio-ansible/group_vars/snapshot "add_modules"
The mod-graphql is the only one missing.