### PR TITLE
Remove ui-marccat FOLIO-2952

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@folio/licenses": ">=2.0.0",
     "@folio/ldp": ">=1.1.0",
     "@folio/local-kb-admin": ">=1.0.0",
-    "@folio/marccat": ">=1.8.5",
     "@folio/myprofile": ">=1.1.0",
     "@folio/notes": ">=1.0.0",
     "@folio/oai-pmh": ">=1.0.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -31,7 +31,6 @@ module.exports = {
     '@folio/ldp' : {},
     '@folio/licenses' : {},
     '@folio/local-kb-admin': {},
-    '@folio/marccat' : {},
     '@folio/myprofile' : {},
     '@folio/notes' : {},
     '@folio/oai-pmh' : {},


### PR DESCRIPTION
The mod-marccat and ui-marccat are to be deprecated. [FOLIO-2952](https://issues.folio.org/browse/FOLIO-2952) and [FOLIO-2953](https://issues.folio.org/browse/FOLIO-2953).