### PR TITLE
STCOR-503 provide react-titled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@
 * Update `moment` to `~2.29.0`. STRIPES-702
 * Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 * Update `react` to `~17.0`. STRIPES-722.
+* Provide `react-titled`. Refs STCOR-503.
 
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-redux": "^7.2.2",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-titled": "^1.0.1",
     "redux": "^4.0.5"
   },
   "devDependencies": {
@@ -81,7 +82,7 @@
   "resolutions": {
     "rxjs": "^5.4.3",
     "minimist": "^1.2.3",
-    "moment": "~2.29.0", 
+    "moment": "~2.29.0",
     "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
Provide `react-titled` as a peer dep because the apps will pull it from
context and therefore must depend on exactly the same version.

Refs [STCOR-503](https://issues.folio.org/browse/STCOR-503)