### PR TITLE
STRIPES-733 update stripes-cli to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,5 @@
 * Update `moment` to `~2.29.0`. STRIPES-702
 * Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 * Provide `react-titled`. Refs STCOR-503.
-
+* Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
 

--- a/package.json
+++ b/package.json
@@ -75,11 +75,12 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {
+    "@folio/stripes-cli": "^2.0.0",
     "rxjs": "^5.4.3",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
Pin `@folio/stripes-cli` to `v2` via resolutions so we don't get
multiple copies of `@folio/stripes-core` and `@folio/stripes-components`
via `v1`. We can remove the resolutions entry as soon as all the tickets
linked to [STCLI-169](https://issues.folio.org/browse/STCLI-169) are closed.

Refs [STRIPES-733](https://issues.folio.org/browse/STRIPES-733)