### PR TITLE
Remove UI data export manager FOLIO-3064

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@folio/eholdings": ">=1.1.0",
     "@folio/erm-comparisons": ">=1.0.0",
     "@folio/erm-usage": ">=1.0.3",
-    "@folio/export-manager": ">=1.0.0",
     "@folio/finance": ">=1.1.0",
     "@folio/inventory": ">=1.4.0",
     "@folio/inventory-es": ">=5.0.1",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -25,7 +25,6 @@ module.exports = {
     '@folio/eholdings' : {},
     '@folio/erm-comparisons': {},
     '@folio/erm-usage' : {},
-    '@folio/export-manager': {},
     '@folio/inventory' : {},
     '@folio/inventory-es' : {},
     '@folio/invoice' : {},


### PR DESCRIPTION
In order to be able to build the snapshot hosted reference environment, the data export manager UI module needs to be removed from Platform Complete, so that `mod-data-export-spring` which is [failing](https://issues.folio.org/browse/MODEXPS-5) is also removed from the environment build.

The change is based upon the [commit](https://github.com/folio-org/platform-complete/commit/e527e4ec0756254c5b1635044290567ef67016b6) used to add it. It cannot be a straight revert as the commit includes adding the new bursar module as well.