### PR TITLE
UIOR-680 lock final-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "resolutions": {
     "@folio/stripes-cli": "^2.0.0",
+    "final-form": "4.20.1",
     "rxjs": "^5.4.3",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
final-form v4.20.2 contains breaking change, at least in one place. Easy fix was not found, github issue is filed for maintainers, but to unblock release we might need to lock previous version for the platform.
https://issues.folio.org/browse/UIOR-680