### PR TITLE
Upgrade stripes-cli dependency to ^2.2.0

### DIFF
--- a/install.json
+++ b/install.json
@@ -119,7 +119,7 @@
   "id" : "mod-data-import-converter-storage-1.10.0",
   "action" : "enable"
 }, {
-  "id" : "mod-source-record-manager-3.0.3",
+  "id" : "mod-source-record-manager-3.0.4",
   "action" : "enable"
 }, {
   "id" : "mod-data-import-2.0.1",

--- a/install.json
+++ b/install.json
@@ -71,7 +71,7 @@
   "id" : "mod-tags-0.8.0",
   "action" : "enable"
 }, {
-  "id" : "mod-orders-12.0.0",
+  "id" : "mod-orders-12.0.1",
   "action" : "enable"
 }, {
   "id" : "folio_acquisition-units-2.3.0",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -96,7 +96,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-orders-12.0.0",
+    "id": "mod-orders-12.0.1",
     "action": "enable"
   },
   {

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -124,7 +124,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-source-record-manager-3.0.3",
+    "id": "mod-source-record-manager-3.0.4",
     "action": "enable"
   },
   {

--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-cli": "^2.1.0",
+    "@folio/stripes-cli": "^2.2.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "@folio/stripes-cli": "^2.1.0",
+    "@folio/stripes-cli": "^2.2.0",
     "final-form": "4.20.1",
     "react-hot-loader": "4.8.8",
     "rxjs": "^5.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@apollo/client@^3.2.1":
-  version "3.3.14"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.14.tgz#b077f42e17941dbf4c62c4f41bf83c0828872d09"
-  integrity sha512-z7YwMvF9grmpWUG+26e3gPcBAOA/r/Ci5gwK7JVm3bGYG9kKqG8MF6sMXEbuwTsFseE4duSp0icJ6tdzxJhhlA==
+  version "3.3.15"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.3.15.tgz#bdd230894aac4beb8ade2b472a1d3c9ea6152812"
+  integrity sha512-/WQmNvLEZMA0mA3u+FkEPTXKzxZD/KhyO7WlbKcy3zKGrXKza83tAbNMzsitQE7DTcSc3DLEcIu1Z5Rc7PFq0Q==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@types/zen-observable" "^0.8.0"
@@ -1842,13 +1842,13 @@
     react-hot-loader "^4.3.12"
     redux-form "^8.3.0"
 
-"@folio/stripes-cli@^2.1.0":
-  version "2.1.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-cli/-/stripes-cli-2.1.0.tgz#b0cc0dc6ecc54d6593f766305145046bd8712a51"
-  integrity sha512-7u+P+AzCt0MhTV5SPxBSFL9/rdsJ9wd7jTJXCb/eQ0pdAnnPPCV1tdcGMeOZHeT7YyXTxqHoYkJucPf0SIZjIQ==
+"@folio/stripes-cli@^2.2.0":
+  version "2.2.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-cli/-/stripes-cli-2.2.0.tgz#23380f60bc36115beca2686390370c28990649cc"
+  integrity sha512-9deNVbcM+lLgkh6C9kOqevvBQhG4AhwSgIXQiq9FWXqHAhw3lx5bh4rbnjK4gRkvRoqWY7tZrGgdOoguQjZXmg==
   dependencies:
     "@folio/stripes-testing" "^3.0.0"
-    "@folio/stripes-webpack" "^1.0.0"
+    "@folio/stripes-webpack" "^1.2.0"
     "@octokit/rest" "^17.1.4"
     babel-plugin-istanbul "^4.1.6"
     configstore "^3.1.1"
@@ -2108,7 +2108,7 @@
     lodash "^4.17.4"
     query-string "^5.0.0"
 
-"@folio/stripes-webpack@^1.0.0":
+"@folio/stripes-webpack@^1.2.0":
   version "1.2.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-webpack/-/stripes-webpack-1.2.0.tgz#95a70a29798ef2e640edf3bc274a5f7d9fcfe77b"
   integrity sha512-PIzJGKQC5NORtRfYUVs0iBArD/7PZgB5Mr+Acp78gYy85itrfCsy3/zBIoZu5RLQC06Gkt0etRLzV4WFmbG1tQ==
@@ -5806,9 +5806,9 @@ ejs@^2.2.4, ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.712:
-  version "1.3.713"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.713.tgz#4583efb17f2d1e9ec07a44c8004ea73c013ad146"
-  integrity sha512-HWgkyX4xTHmxcWWlvv7a87RHSINEcpKYZmDMxkUlHcY+CJcfx7xEfBHuXVsO1rzyYs1WQJ7EgDp2CoErakBIow==
+  version "1.3.716"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.716.tgz#cadedb3d07776c56990cedff1a75488afeeac2e0"
+  integrity sha512-yUWKAfpJH5ovgwIlNbBHioedAWolzTVl6tmMaXP1RmCMyYv+U+ukvo9gwA10mLW0eFbyW4n/oC4UIN12gTMn/w==
 
 element-is-visible@^1.0.0:
   version "1.0.0"
@@ -11692,9 +11692,9 @@ react-overlays@^3.2.0:
     warning "^4.0.3"
 
 react-query@^3.13.0, react-query@^3.6.0, react-query@^3.9.8:
-  version "3.13.6"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.13.6.tgz#59d9a17b5f78ea674010bc69525dd1b189e2177b"
-  integrity sha512-PIj4WsDycyTs4oVa8hZ09t1MXy77N1ik9lGTO7tHAPg2A1v+9wHMLqD2/Nrp4ALL32Diw4R2gq/Fq9StxOh+gg==
+  version "3.13.8"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.13.8.tgz#fe82aa80064857bde93eb571534190554addb2d5"
+  integrity sha512-0zujQNExerbNgULg3W+7PKTyf/iGzTdBExUaRIxb/mLa+Ghc5QKl/5c8yqkwwvlAFUUX8GAQ/Qu3l46SKOWCOg==
   dependencies:
     "@babel/runtime" "^7.5.5"
     broadcast-channel "^3.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,9 +5355,9 @@ date-arithmetic@^4.0.1:
   integrity sha512-QWxYLR5P/6GStZcdem+V1xoto6DMadYWpMXU82ES3/RfR3Wdwr3D0+be7mgOJ+Ov0G9D5Dmb9T17sNLQYj9XOg==
 
 date-fns@^2.16.1:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.20.3.tgz#5a28718edb95a80db96187b25340959867d36bc8"
-  integrity sha512-BbiJSlfmr1Fnfi1OHY8arklKdwtZ9n3NkjCeK8G9gtEe0ZSUwJuwHc6gYBl0uoC0Oa5RdpJV1gBBdXcZi8Efdw==
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.21.0.tgz#4672b8e926d1b37d5353dc14da44b883481ac927"
+  integrity sha512-lbAFpaKz7QuVxm6m1rmioh4BB2gmLx1r1JMYXU2A/ufT5ly4zEG7HYH4fvS/QfbdyC5rkYyiS30mYz4Q7XCO+w==
 
 date-format@^2.0.0:
   version "2.1.0"
@@ -5806,9 +5806,9 @@ ejs@^2.2.4, ejs@^2.6.1:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.712:
-  version "1.3.716"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.716.tgz#cadedb3d07776c56990cedff1a75488afeeac2e0"
-  integrity sha512-yUWKAfpJH5ovgwIlNbBHioedAWolzTVl6tmMaXP1RmCMyYv+U+ukvo9gwA10mLW0eFbyW4n/oC4UIN12gTMn/w==
+  version "1.3.717"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz#78d4c857070755fb58ab64bcc173db1d51cbc25f"
+  integrity sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==
 
 element-is-visible@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This in turn requires `stripes-webpack` ^1.2.0, which supports loading CSV files.