### PR TITLE
lock @rehooks/local-storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
   },
   "resolutions": {
     "@folio/stripes-cli": "^2.0.0",
+    "@rehooks/local-storage": "2.4.0",
     "final-form": "4.20.1",
     "rxjs": "^5.4.3",
     "minimist": "^1.2.3",


### PR DESCRIPTION
part of our modules that use PersistedPaneset are broken (including bugfest env) because of release of  @rehooks/local-storage that was done yesterday
https://github.com/rehooks/local-storage/issues/77

lock version should fix the issue