### PR TITLE
re-add z3950/graphql modules

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -40,6 +40,14 @@
     "action": "enable"
   },
   {
+    "id": mod-graphql-1.9.0",
+    "action": "enable"
+  },
+  {
+    "id": mod-z3950-2.3.0",
+    "action": "enable"
+  },
+  {
     "id": "mod-ebsconet-1.0.1",
     "action": "enable"
   },

--- a/install-extras.json
+++ b/install-extras.json
@@ -44,7 +44,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-z3950-2.3.0",
+    "id": "mod-z3950-2.4.0",
     "action": "enable"
   },
   {

--- a/install-extras.json
+++ b/install-extras.json
@@ -40,11 +40,11 @@
     "action": "enable"
   },
   {
-    "id": mod-graphql-1.9.0",
+    "id": "mod-graphql-1.9.0",
     "action": "enable"
   },
   {
-    "id": mod-z3950-2.3.0",
+    "id": "mod-z3950-2.3.0",
     "action": "enable"
   },
   {

--- a/install.json
+++ b/install.json
@@ -347,6 +347,12 @@
   "id" : "okapi-4.8.2",
   "action" : "enable"
 }, {
+  "id" : "mod-graphql-1.9.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-z3950-2.4.0",
+  "action" : "enable"
+}, {
   "id" : "mod-ebsconet-1.0.1",
   "action" : "enable"
 }, {

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -216,6 +216,14 @@
     "action": "enable"
   },
   {
+    "id": "mod-graphql-1.9.0",
+    "action": "enable"
+  },
+  {
+    "id": "mod-z3950-2.4.0",
+    "action": "enable"
+  },
+  {
     "id": "mod-ebsconet-1.0.1",
     "action": "enable"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5834,9 +5834,9 @@ ejs@^2.2.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.3.811:
-  version "1.3.814"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.814.tgz#418fad80c3276a46103ca72a21a8290620d83c4a"
-  integrity sha512-0mH03cyjh6OzMlmjauGg0TLd87ErIJqWiYxMcOLKf5w6p0YEOl7DJAj7BDlXEFmCguY5CQaKVOiMjAMODO2XDw==
+  version "1.3.816"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.816.tgz#ab6488b126de92670a6459fe3e746050e0c6276f"
+  integrity sha512-/AvJPIJldO0NkwkfpUD7u1e4YEGRFBQpFuvl9oGCcVgWOObsZB1loxVGeVUJB9kmvfsBUUChPYdgRzx6+AKNyg==
 
 element-is-visible@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Somehow mod-z3950 and mod-graphql were left out of the R2 release branch.  Re-add them both. 