### PR TITLE
UISEES-70 remove ui-inventory-es given ui-inventory has facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@folio/handler-stripes-registry": ">=1.0.0",
     "@folio/inn-reach": ">=1.1.0",
     "@folio/inventory": ">=1.4.0",
-    "@folio/inventory-es": ">=1.6.0",
     "@folio/invoice": ">=1.0.0",
     "@folio/ldp": ">=1.1.0",
     "@folio/licenses": ">=2.0.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -31,7 +31,6 @@ module.exports = {
     '@folio/handler-stripes-registry': {},
     '@folio/inn-reach' : {},
     '@folio/inventory' : {},
-    '@folio/inventory-es' : {},
     '@folio/invoice' : {},
     '@folio/finance' : {},
     '@folio/ldp' : {},


### PR DESCRIPTION
All mod-search related endpoints and components have been implemented
directly in ui-inventory since UIIN-1567. Consequently, ui-inventory-es
may be removed.

Refs [UISEES-70](https://issues.folio.org/browse/UISEES-70), [UIIN-1567](https://issues.folio.org/browse/UIIN-1567)