### PR TITLE
STRIPES-723 provide rxjs v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,5 @@
 * Provide `react-titled`. Refs STCOR-503.
 * Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
 * Provide `react-query` and `swr`. Refs STRIPES-735.
-
+* Update `react` to `v171. Refs STRIPES-722.
+* Provide `rxjs` `v6`. Refs STRIPES-723.

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "@folio/organizations": ">=1.0.0",
     "@folio/plugin-bursar-export": ">=1.0.0",
     "@folio/plugin-create-inventory-records": ">=1.0.0",
+    "@folio/plugin-eusage-reports": ">=1.0.0",
     "@folio/plugin-find-agreement": ">=2.0.0",
     "@folio/plugin-find-contact": ">=1.0.0",
     "@folio/plugin-find-eresource": ">=1.0.0",
-    "@folio/plugin-eusage-reports": ">=1.0.0",
     "@folio/plugin-find-erm-usage-data-provider": ">=1.0.0",
     "@folio/plugin-find-import-profile": ">=1.1.0",
     "@folio/plugin-find-instance": ">=1.1.0",
@@ -81,6 +81,7 @@
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",
     "redux": "^4.0.5",
+    "rxjs": "^6.6.7",
     "swr": "^0.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Provide `rxjs` `v6` as a dependency, allowing apps to include it as a
peer-dependency.

Refs [STRIPES-723](https://issues.folio.org/browse/STRIPES-723)