### PR TITLE
ERM-1748 rm final-form resolutions entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,11 +94,9 @@
   "resolutions": {
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
-    "final-form": "4.20.1",
+    "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
-    "redux-form": "^8.0.0",
-    "rxjs": "^5.4.3",
-    "style-loader": "^1.0.0"
+    "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
We locked onto `final-form` `4.20.1` because of a bug introduced in
`4.20.2` that now appears to be resolved, so now we can finally unblock
and get the fix for `DragAndDropFieldArray` that has been there since
`4.20.2` but was unavailable to us.

Refs [ERM-1748](https://issues.folio.org/browse/ERM-1748)