### PR TITLE
FOLIO-3309 deps must be compatible with stripes v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "@folio/tenant-settings": "7.0.0",
     "@folio/users": "6.1.4",
     "moment": "~2.29.0",
-    "react": "~16.14.0",
-    "react-dom": "~16.14.0",
+    "react": "~17.0.2",
+    "react-dom": "~17.0.2",
     "react-intl": "^5.7.0",
     "react-query": "^3.13.0",
     "react-redux": "^7.2.2",
@@ -76,22 +76,22 @@
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",
     "redux": "^4.0.5",
+    "rxjs": "^6.6.7",
     "swr": "^0.4.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-cli": "2.4.0",
+    "@folio/stripes-cli": "^2.4.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "@folio/stripes-cli": "2.4.0",
-    "final-form": "4.20.4",
-    "redux-form": "^8.0.0",
-    "@rehooks/local-storage": "2.4.0",
-    "rxjs": "^5.4.3",
     "@folio/react-intl-safe-html": "3.0.0",
+    "@folio/stripes-cli": "^2.4.0",
+    "@rehooks/local-storage": "2.4.0",
+    "final-form": "^4.20.4",
     "minimist": "^1.2.3",
-    "moment": "~2.29.1"
+    "moment": "~2.29.1",
+    "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
Update package versions provided by the platform, which applications
peer from, so they are compatible with `stripes` `v7`.

Refs [FOLIO-3309](https://issues.folio.org/browse/FOLIO-3309), [STRIPES-722](https://issues.folio.org/browse/STRIPES-722), [STRIPES-723](https://issues.folio.org/browse/STRIPES-723)