### PR TITLE
FOLIO-3342 lock to react-intl v5.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
 * Provide `react-query` and `swr`. Refs STRIPES-735.
 * Update `react` to `v171. Refs STRIPES-722.
 * Provide `rxjs` `v6`. Refs STRIPES-723.
+* Lock to `react-intl` `v5.21.1`. Refs FOLIO-3342.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "moment": "~2.29.0",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",
-    "react-intl": "^5.7.0",
+    "react-intl": "5.21.0",
     "react-query": "^3.13.0",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.0",


### PR DESCRIPTION
[`react-intl` `v5.21.1` includes breaking changes](https://github.com/formatjs/formatjs/issues/3263) to how null values are
handled in `<FormattedMessage>` values (previously they were replaced
with empty strings, now they are replaced by their keys).

Refs [FOLIO-3342](https://issues.folio.org/browse/FOLIO-3342)
<img width="608" alt="Screen Shot 2021-11-11 at 1 22 24 PM (2)" src="https://user-images.githubusercontent.com/199241/141361371-48be7f54-eb52-4ce5-a439-db960355ec95.png">


