### PR TITLE
FOLIO-3383 avoid sabotaged colors > 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 * Update `react` to `v171. Refs STRIPES-722.
 * Provide `rxjs` `v6`. Refs STRIPES-723.
 * Lock to `react-intl` `v5.21.1`. Refs FOLIO-3342.
+* Lock to `colors` `1.4.0`. Refs FOLIO-3383.

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
   "resolutions": {
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
+    "colors": "1.4.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
The owner of `colors` [sabotaged the package in releases > 1.4.0, adding
an infinite loop and verbose log output](https://www.bleepingcomputer.com/news/security/dev-corrupts-npm-libs-colors-and-faker-breaking-thousands-of-apps/).

Refs [FOLIO-3383](https://issues.folio.org/browse/FOLIO-3383).