### PR TITLE
RANCHER-129 Adjust python version for BUILD-UI pipeline

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /etc/folio/stripes
 
 COPY . /etc/folio/stripes/
 
-RUN apk add --no-cache alpine-sdk python2
-RUN yarn config set python /usr/bin/python2
+RUN apk add --no-cache alpine-sdk python3
+RUN yarn config set python /usr/bin/python3
 
 RUN yarn config set @folio:registry https://repository.folio.org/repository/npm-folioci/
 RUN yarn install


### PR DESCRIPTION
***Problem description:***
Python version should be changed for docker image, that used in BUILD-UI pipeline.
Python3 became mandatory for some node components.

***Revert options:***
Can be easily reverted by python version adjustment.