### PR TITLE
MODLOGSAML-130: mod-login-saml v2.4.0, Pac4j 5.2.1 (R3-2021)

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -300,7 +300,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-login-saml-2.3.2",
+    "id": "mod-login-saml-2.4.0",
     "action": "enable"
   },
   {

--- a/install.json
+++ b/install.json
@@ -311,7 +311,7 @@
   "id" : "folio_tags-6.0.0",
   "action" : "enable"
 }, {
-  "id" : "mod-login-saml-2.3.2",
+  "id" : "mod-login-saml-2.4.0",
   "action" : "enable"
 }, {
   "id" : "folio_tenant-settings-7.0.1",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -204,7 +204,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-login-saml-2.3.2",
+    "id": "mod-login-saml-2.4.0",
     "action": "enable"
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4746,9 +4746,9 @@ clean-css@^4.2.3:
     source-map "~0.6.0"
 
 clean-css@^5.2.2:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.2.3.tgz#efca57c1f90303a5438939fecbc3786b1fe5e31a"
-  integrity sha512-qjywD7LvpZJ5+E16lf00GnMVUX5TEVBcKW1/vtGPgAerHwRwE4JP4p1Y40zbLnup2ZfWsd30P2bHdoAKH93XxA==
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.2.4.tgz#982b058f8581adb2ae062520808fb2429bd487a4"
+  integrity sha512-nKseG8wCzEuji/4yrgM/5cthL9oTDc5UOQyFMvW/Q53oP6gLH690o1NbuTh6Y18nujr7BxlsFuS7gXLnLzKJGg==
   dependencies:
     source-map "~0.6.0"
 
@@ -5986,9 +5986,9 @@ ejs@^2.2.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.4.17:
-  version "1.4.56"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.56.tgz#f660fd2c6739b341d8922fe3a441a5a2804911a1"
-  integrity sha512-0k/S0FQqRRpJbX7YUjwCcLZ8D42RqGKtaiq90adXBOYgTIWwLA/g3toO8k9yEpqU8iC4QyaWYYWSTBIna8WV4g==
+  version "1.4.57"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.57.tgz#2b2766df76ac8dbc0a1d41249bc5684a31849892"
+  integrity sha512-FNC+P5K1n6pF+M0zIK+gFCoXcJhhzDViL3DRIGy2Fv5PohuSES1JHR7T+GlwxSxlzx4yYbsuzCZvHxcBSRCIOw==
 
 element-is-visible@^1.0.0:
   version "1.0.0"
@@ -8739,9 +8739,9 @@ jspdf-autotable@^3.5.14:
   integrity sha512-uIYxQsdKrDdbhygEFlbTVoaxawZMZXMasAOryQ1oMFTragcxLhhWIfc8peLCBXuB7fJ5SICtPZ2De7Pk7eS8SQ==
 
 jspdf@^2.3.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/jspdf/-/jspdf-2.5.0.tgz#d0a1a2a9a73f0e7bc00599315ab5a9c825cbbcc2"
-  integrity sha512-XT0E2m8A9P1xl7ItA2OUbmhokzbDQEyZEdWQZD2olADiTiBEZGDRiK1J1zWxBRUG2KezQJOZq//GYZTkvEZuJg==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jspdf/-/jspdf-2.5.1.tgz#00c85250abf5447a05f3b32ab9935ab4a56592cc"
+  integrity sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==
   dependencies:
     "@babel/runtime" "^7.14.0"
     atob "^2.1.2"
@@ -11588,9 +11588,9 @@ react-dropzone@^10.0.0:
     prop-types "^15.7.2"
 
 react-dropzone@^11.3.4:
-  version "11.5.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.5.1.tgz#f4d664437bf8af6acfccbf5040a9890c6780a49f"
-  integrity sha512-eNhttdq4ZDe3eKbXAe54Opt+sbtqmNK5NWTHf/l5d+1TdZqShJ8gMjBrya00qx5zkI//TYxRhu1d9pemTgaWwg==
+  version "11.5.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.5.3.tgz#757d4980fcae839896a894e41d3e72df04981f86"
+  integrity sha512-68+T6sWW5L89qJnn3SD1aRazhuRBhTT9JOI1W8vI5YWsfegM4C7tlGbPH1AgEbmZY5s8E8L0QhX0e3VdAa0KWA==
   dependencies:
     attr-accept "^2.2.1"
     file-selector "^0.2.2"


### PR DESCRIPTION
The core platform team decided that mod-login-saml v2.4.0 should be used for hotfixing Iris, Juniper and Kiwi.

mod-login-saml v2.4.0 was released with pac4j bumped from 5.1.4 to v5.2.1 fixing the unsecure token security issue:
* https://nvd.nist.gov/vuln/detail/CVE-2021-44878
* https://issues.folio.org/browse/MODLOGSAML-130

mod-login-saml v2.4.0 contains other minor bug fixes and library updates, but no new features.

The previous mod-login-saml release is v2.3.2 and uses pac4j v4.3.0 and vertx-pac4j v5.0.2-FOLIO.1 and is affected by the unsecure token issue, however, pac4j v4.* and vertx-pac4j 5.* are no longer maintained and don't get security fixes.

(cherry picked from commit 5e3a016d98e1261ba6a2820aa0eecc6a63f35364)