### PR TITLE
UIU-2549 bump @folio/users to 8.0

### DIFF
--- a/install.json
+++ b/install.json
@@ -227,7 +227,7 @@
   "id" : "folio_stripes-core-8.1.0",
   "action" : "enable"
 }, {
-  "id" : "folio_users-7.1.0",
+  "id" : "folio_users-8.0.0",
   "action" : "enable"
 }, {
   "id" : "edge-inn-reach-1.0.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@folio/stripes-erm-components": "6.1.0",
     "@folio/tags": "6.1.0",
     "@folio/tenant-settings": "7.1.0",
-    "@folio/users": "7.1.0",
+    "@folio/users": "8.0.0",
     "moment": "~2.29.0",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",

--- a/stripes-install.json
+++ b/stripes-install.json
@@ -224,7 +224,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_users-7.1.0",
+    "id": "folio_users-8.0.0",
     "action": "enable"
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,10 +2445,10 @@
     react-final-form-arrays "^3.1.1"
     redux-form "^8.0.0"
 
-"@folio/users@7.1.0":
-  version "7.1.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/users/-/users-7.1.0.tgz#34c6605e0273382cac4f6a2b7807e5d943c0e0ad"
-  integrity sha512-0MZATBAVgMmFM1WxLsBIZ1ebPZPlEgKPVoCne3ZeKyZb14pt4L39dV/ZTq3pOTpb6tdSwoNYeqMcU29oLYxTrQ==
+"@folio/users@8.0.0":
+  version "8.0.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/users/-/users-8.0.0.tgz#08ca7d3f294e4e14c56270c12601f23063d07ca7"
+  integrity sha512-ge7kvWCEHRgcBVpQqg4vPqqtkcgpawk12G1NOV6MN62uWZFWB1uIRExyRJohYnPuA8GBbWPO2Rw9PfhsQZhlzA==
   dependencies:
     final-form-set-field-data "^1.0.2"
     hashcode "^1.0.3"
@@ -3269,9 +3269,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
-  version "7.0.9"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
-  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.10.tgz#9b05b7896166cd00e9cbd59864853abf65d9ac23"
+  integrity sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -4310,12 +4310,12 @@ browserify-sign@^4.0.0:
     safe-buffer "^5.2.0"
 
 browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.17.5, browserslist@^4.19.1:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.0.tgz#35951e3541078c125d36df76056e94738a52ebe9"
-  integrity sha512-bnpOoa+DownbciXj0jVGENf8VYQnE2LNWomhYuCsMmmx9Jd9lwq0WXODuwpSsp8AVdKM2/HorrzxAfbKvWTByQ==
+  version "4.20.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.2.tgz#567b41508757ecd904dab4d1c646c612cd3d4f88"
+  integrity sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==
   dependencies:
-    caniuse-lite "^1.0.30001313"
-    electron-to-chromium "^1.4.76"
+    caniuse-lite "^1.0.30001317"
+    electron-to-chromium "^1.4.84"
     escalade "^3.1.1"
     node-releases "^2.0.2"
     picocolors "^1.0.0"
@@ -4472,7 +4472,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001313:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001317:
   version "1.0.30001317"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001317.tgz#0548fb28fd5bc259a70b8c1ffdbe598037666a1b"
   integrity sha512-xIZLh8gBm4dqNX0gkzrBeyI86J2eCjWzYAs40q88smG844YIrN4tVQl/RhquHvKEKImWWFIVh1Lxe5n1G/N+GQ==
@@ -5766,10 +5766,10 @@ ejs@^2.2.4:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.4.76:
-  version "1.4.84"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.84.tgz#2700befbcb49c42c4ee162e137ff392c07658249"
-  integrity sha512-b+DdcyOiZtLXHdgEG8lncYJdxbdJWJvclPNMg0eLUDcSOSO876WA/pYjdSblUTd7eJdIs4YdIxHWGazx7UPSJw==
+electron-to-chromium@^1.4.84:
+  version "1.4.86"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.86.tgz#90fe4a9787f48d6522957213408e08a8126b2ebc"
+  integrity sha512-EVTZ+igi8x63pK4bPuA95PXIs2b2Cowi3WQwI9f9qManLiZJOD1Lash1J3W4TvvcUCcIR4o/rgi9o8UicXSO+w==
 
 element-is-visible@^1.0.0:
   version "1.0.0"
@@ -10504,9 +10504,9 @@ postcss@^7.0.32:
     source-map "^0.6.1"
 
 postcss@^8.3.5, postcss@^8.3.9, postcss@^8.4.7:
-  version "8.4.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.8.tgz#dad963a76e82c081a0657d3a2f3602ce10c2e032"
-  integrity sha512-2tXEqGxrjvAO6U+CJzDL2Fk2kPHTv1jQsYkSoMeOis2SsYaXRO2COxTdQp99cYvif9JTXaAk9lYGc3VhJt7JPQ==
+  version "8.4.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.12.tgz#1e7de78733b28970fa4743f7da6f3763648b1905"
+  integrity sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==
   dependencies:
     nanoid "^3.3.1"
     picocolors "^1.0.0"


### PR DESCRIPTION
Bump `@folio/users` to `8.0.0`, requiring `permissions` interface `5.5`
in order to update the `ui-users.editperms` permission set with
`perms.users.assign.mutable` and `perms.users.assign.immutable` so they
can continue to grant permissions they do not already own.

Refs [UIU-2549](https://issues.folio.org/browse/UIU-2549)