### PR TITLE
FOLIO-3466: Spring4Shell: spring-beans RCE Vuln (CVE-2022-22965)

### DIFF
--- a/.github/workflows/spring-cve-2022-22965.yml
+++ b/.github/workflows/spring-cve-2022-22965.yml
@@ -1,0 +1,52 @@
+name: spring-cve-2022-22965
+on:
+  workflow_dispatch:
+  schedule:
+  - cron:  '39 3,9,15,21 * * *'
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release: ["master", "R3-2021"]
+    steps:
+      - name: Analyze
+        run: |
+          echo "Spring4Shell CVE-2022-22965 - list spring-beans existence, mark <5.3.18 or <5.2.20.RELEASE as vuln" > result.txt
+          echo >> result.txt
+          wget https://grails.org/files/wrapper-issue7/grails4/grails-wrapper.jar
+          git config --global advice.detachedHead false
+          INSTALL=$( curl -sS https://raw.githubusercontent.com/folio-org/platform-complete/${{ matrix.release }}/install.json \
+                     | jq -r '.[].id' \
+                     | sed -E 's/-([0-9])/:\1/' \
+                     | grep -v '^folio_' \
+                     | sort -u )
+          for M in $INSTALL
+          do
+            echo "M=$M"
+            MOD=$(echo $M | cut -d: -f1)
+            VER=$(echo $M | cut -d: -f2)
+            if [ "$MOD" = "mod-z3950" ]
+            then
+              MOD="Net-Z3950-FOLIO"
+            fi
+            git clone --branch "v$VER" --single-branch "https://github.com/folio-org/$MOD"
+            cp grails-wrapper.jar "$MOD/service/" || true
+            SPRING=$( ( cd $MOD; mvn dependency:tree \
+                          | sed -n -E 's/^.* org.springframework:spring-beans:jar:([^:]+):.*/\1/p'; \
+                        cd service; \
+                        ./grailsw dependency-report runtime \
+                          | sed -n -E 's/^.* org.springframework:spring-beans:([^ ]+)$/\1/p' \
+                      ) | sort -u )
+            if [ -z "$SPRING" ]
+            then
+              R="ok"
+            elif echo "$SPRING" | grep -v --line-regexp -e 5.3.18 -e 5.3.19 -e 5.3.20   -e 5.2.20.RELEASE -e 5.2.21.RELEASE -e 5.2.22.RELEASE > /dev/null
+            then
+              R="vuln"
+            else
+              R="ok"
+            fi
+            printf "%4s %-14s %s\n" "$R" "$SPRING" "$M" >> result.txt
+          done
+      - run: cat result.txt

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,7 +3796,7 @@ array-flatten@1.1.1:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
 
-array-includes@^3.1.1, array-includes@^3.1.3:
+array-includes@^3.1.1, array-includes@^3.1.3, array-includes@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
   integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
@@ -8394,11 +8394,11 @@ jstransformer@^1.0.0:
     promise "^7.0.1"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz#720b97bfe7d901b927d87c3773637ae8ea48781b"
-  integrity sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.2.tgz#6ab1e52c71dfc0c0707008a91729a9491fe9f76c"
+  integrity sha512-HDAyJ4MNQBboGpUnHAVUNJs6X0lh058s6FuixsFGP7MgJYpD6Vasd6nzSG5iIfXu1zAYlHJ/zsOKNlrenTUBnw==
   dependencies:
-    array-includes "^3.1.3"
+    array-includes "^3.1.4"
     object.assign "^4.1.2"
 
 just-curry-it@^3.1.0:
@@ -11243,9 +11243,9 @@ react-titled@^1.0.0, react-titled@^1.0.1:
     prop-types "^15.5.8"
 
 react-to-print@^2.12.3, react-to-print@^2.3.2, react-to-print@^2.9.0:
-  version "2.14.4"
-  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.14.4.tgz#9d1390b3f192fe55e8ccadca7bda1edb409fd1bf"
-  integrity sha512-lpKKsmkZz1m4G1mBbJtK5qATfYzJRrgLgJ3m0LyF17Ojq22ifxw2AIgH3BROpFDNj0c057Q1dDP53kDIPLVtmw==
+  version "2.14.5"
+  resolved "https://registry.yarnpkg.com/react-to-print/-/react-to-print-2.14.5.tgz#48ea5af6b73ee514772da96e4b98694cba1cec70"
+  integrity sha512-FeFBo4oRscVNiuw9/qET3RHOArN5wo1z0skzABdzFaxZNIy6FM8beJyBHxYWsiQ92M6Dv2To9Fp03Gve02GS5A==
   dependencies:
     prop-types "^15.8.1"
 


### PR DESCRIPTION
List spring-beans existence and show vulnerable and fixed versions.