### PR TITLE
FOLIO-3445 Jenkins cleanup wait

### DIFF
--- a/Jenkinsfile.build
+++ b/Jenkinsfile.build
@@ -168,6 +168,8 @@ pipeline {
       sendNotifications currentBuild.result
     }
     cleanup {
+      echo "Sleeping during cleanup to enable ansible error reporting."
+      sleep 10
       withCredentials([[$class: 'AmazonWebServicesCredentialsBinding',
                         accessKeyVariable: 'AWS_ACCESS_KEY_ID',
                         credentialsId: 'jenkins-aws',


### PR DESCRIPTION
Add echo/wait to Jenkinsfile.build cleanup phase to flush buffer from Ansible playbook plugin and ensure console log is sensible.