### PR TITLE
FOLIO-3503 unlock react-intl from v5.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 * Provide `rxjs` `v6`. Refs STRIPES-723.
 * Lock to `react-intl` `v5.21.1`. Refs FOLIO-3342.
 * Lock to `colors` `1.4.0`. Refs FOLIO-3383.
+* Unlock `react-intl` from `v5.21.0`. Refs FOLIO-3503.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "moment": "~2.29.0",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",
-    "react-intl": "5.21.0",
+    "react-intl": "^5.25.1",
     "react-query": "^3.13.0",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.0",


### PR DESCRIPTION
We locked to `"5.21.0"` in #1625 to resolve [FOLIO-3342](https://issues.folio.org/browse/FOLIO-3342), a breaking
change in a patch release of react-intl. That change was subsequently
reverted, so our lock can be reverted as well. This will also allow the
platform to be more tolerant of dependency glitches in other repos (e.g.
FOLIO-3477).

Refs [FOLIO-3503](https://issues.folio.org/browse/FOLIO-3503), [FOLIO-3477](https://issues.folio.org/browse/FOLIO-3477), [FOLIO-3342](https://issues.folio.org/browse/FOLIO-3342)