### PR TITLE
FOLIO-3547 pin plugin deps to guarantee compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,13 @@
   },
   "resolutions": {
     "colors": "1.4.0",
+    "@folio/plugin-find-contact": "3.1.1",
+    "@folio/plugin-find-fund": "1.0.0",
+    "@folio/plugin-find-instance": "6.1.6",
+    "@folio/plugin-find-interface": "3.1.1",
+    "@folio/plugin-find-organization": "3.1.1",
+    "@folio/plugin-find-po-line": "3.1.1",
+    "@folio/plugin-find-user": "6.1.0",
     "@folio/react-intl-safe-html": "3.1.0",
     "@folio/stripes-cli": "~2.5.0",
     "@rehooks/local-storage": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,16 +1776,7 @@
     lodash "^4.17.11"
     prop-types "^15.6.0"
 
-"@folio/plugin-find-contact@*":
-  version "3.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-contact/-/plugin-find-contact-3.2.0.tgz#ee08e9424294c9bcbaf3b40ce5637d8a8a74e306"
-  integrity sha512-+7pTAVLMdwddK7p6p0B8sMW477Blg56Vsw7OQ+9Ah2LbRDeuUkxm5KFyvDPdQik9/zo7NTW9TfYkVKzpea5kUA==
-  dependencies:
-    "@folio/stripes-acq-components" "~3.2.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-
-"@folio/plugin-find-contact@3.1.1":
+"@folio/plugin-find-contact@*", "@folio/plugin-find-contact@3.1.1":
   version "3.1.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-contact/-/plugin-find-contact-3.1.1.tgz#d2f81ed4d65562c8f6b1ed1197cc9f8598bd60a2"
   integrity sha512-gX00bVAHS8kONOq5apMGcboFPYQmnbtNm5jtQwmLQ9hSbt+46U63HDBkoYoh5ueVTk/OOAyja+K6jqkhoV1rQA==
@@ -1828,16 +1819,7 @@
     lodash "^4.17.11"
     prop-types "^15.6.0"
 
-"@folio/plugin-find-fund@*":
-  version "1.1.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-fund/-/plugin-find-fund-1.1.0.tgz#cf5436159957225956e3f0e5f3fffa99dec1d31f"
-  integrity sha512-vpN+GITPg/DviFE3O2j7aZDKMbKOyKCoYmVL+ouQli+eYHDdU/UVcmCITzWu8M2c+pzvmX4k6l1QNFzma9xqsA==
-  dependencies:
-    "@folio/stripes-acq-components" "~3.2.0"
-    lodash "^4.17.5"
-    prop-types "^15.5.10"
-
-"@folio/plugin-find-fund@1.0.0":
+"@folio/plugin-find-fund@*", "@folio/plugin-find-fund@1.0.0":
   version "1.0.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-fund/-/plugin-find-fund-1.0.0.tgz#0b39a49fd8c0177f31cb568434d04fe35acbf2db"
   integrity sha512-+Bljd4tpXUM7AS9Ko6GWy7rDNZ24sp+TJcVQE8VaLU4pGII8x31T2Ohs3vp5AY2AKadME2wu//l1bsT/SZHJWw==
@@ -1860,19 +1842,7 @@
     react-highlighter "^0.4.3"
     redux-form "^8.3.7"
 
-"@folio/plugin-find-instance@*", "@folio/plugin-find-instance@^6.0.0":
-  version "6.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-instance/-/plugin-find-instance-6.2.0.tgz#ed7d94fae4227b8886762712c79efdc7584714dd"
-  integrity sha512-IJqZrrew0GhoikAnb5mS/91517xUhn/STvjHQi1bdj17aWuJnDdekR+U8+2PDZcRJwDrHJ+tPdoaSkv6qOupYw==
-  dependencies:
-    classnames "^2.2.6"
-    lodash "^4.17.11"
-    moment "^2.29.1"
-    prop-types "^15.6.0"
-    react-query "^3.6.0"
-    sinon "^9.0.2"
-
-"@folio/plugin-find-instance@6.1.6":
+"@folio/plugin-find-instance@*", "@folio/plugin-find-instance@6.1.6", "@folio/plugin-find-instance@^6.0.0":
   version "6.1.6"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-instance/-/plugin-find-instance-6.1.6.tgz#3ea6da46d6fe406f95ac4c618ba4d595132f5b7d"
   integrity sha512-+xHXk6iKIiJEljJ8V043UmoecENKbhaljoKdRkp9k56kTl8/2kw0EiIsDZT2KCLqVFGPE/YIy6/1CvgiWzQPuA==
@@ -1884,16 +1854,7 @@
     react-query "^3.6.0"
     sinon "^9.0.2"
 
-"@folio/plugin-find-interface@*":
-  version "3.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-interface/-/plugin-find-interface-3.2.0.tgz#bf8e3130eae5bbe27f3058ba23f1f5ec439f3060"
-  integrity sha512-4w6l2s3zEyHqYvbgEy+RV8qSFqcUzqwXISXENCzUoDTxaaEf3odXp7x2n9jZTz4sy1dIoa4LU9HKfIkfdGt0DA==
-  dependencies:
-    "@folio/stripes-acq-components" "~3.2.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-
-"@folio/plugin-find-interface@3.1.1":
+"@folio/plugin-find-interface@*", "@folio/plugin-find-interface@3.1.1":
   version "3.1.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-interface/-/plugin-find-interface-3.1.1.tgz#de0636f4d8cbbf9fe5a39a53aaa5783c000aa74c"
   integrity sha512-mc17xvYEOy9dII+pbtPiNX0fhQs/2ztYw4VH8e4KWYNqWbliJNjVEIURWi08hig64M6BZ4bY/1cdWAYKwv9p0w==
@@ -1915,17 +1876,7 @@
     lodash "^4.17.11"
     prop-types "^15.6.0"
 
-"@folio/plugin-find-organization@*":
-  version "3.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-organization/-/plugin-find-organization-3.2.0.tgz#4d264d2cc0677178646d8b70f7e2f6bc847418fa"
-  integrity sha512-zM7qOc/I7QdFPUsKh/Hfnmthm9U2cGPeTRi7BFN5EAJdlzI/vrJwFcf7oZtGfr7nE2btJsaP3ZrF8KaSh1nkmA==
-  dependencies:
-    "@folio/stripes-acq-components" "~3.2.0"
-    classnames "^2.2.5"
-    dom-helpers "^3.4.0"
-    prop-types "^15.6.0"
-
-"@folio/plugin-find-organization@3.1.1":
+"@folio/plugin-find-organization@*", "@folio/plugin-find-organization@3.1.1":
   version "3.1.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-organization/-/plugin-find-organization-3.1.1.tgz#1e59f3e17d393f1a799f0a39a439ebba1427aaa0"
   integrity sha512-mjlRfoQEM78bzVOZrThd2lXIp6t9SIQWbn/1fNVI0lFwpAS2UnCJ+vc6tuZSSnJhd/VawvhqAIJDAcYzskb8yA==
@@ -1946,16 +1897,7 @@
     qs "^6.9.6"
     react-final-form "^6.3.0"
 
-"@folio/plugin-find-po-line@*", "@folio/plugin-find-po-line@^3.1.0":
-  version "3.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-po-line/-/plugin-find-po-line-3.2.0.tgz#f427edac693b8bba459deb03a7ffafad4818be41"
-  integrity sha512-WtyvvZh40gAQ9auWz/K9W3oi2KDU1Z35c+uLvfi18QsB7tgKdRYoqHMeLT1JzzdmPTnWiXCr5IrzFxkJslCw0Q==
-  dependencies:
-    "@folio/stripes-acq-components" "~3.2.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-
-"@folio/plugin-find-po-line@3.1.1":
+"@folio/plugin-find-po-line@*", "@folio/plugin-find-po-line@3.1.1", "@folio/plugin-find-po-line@^3.1.0":
   version "3.1.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-po-line/-/plugin-find-po-line-3.1.1.tgz#aaab8016d7756048b4a452f95a59a13b54398de9"
   integrity sha512-hG65Y+94et4pvf8qaS4eq4KDAPm9q8yq4EFMItqHfB58cNUbUii7gtKQX1kxqLiWHeJcbWSM76rO5NCOaE5uYA==
@@ -1964,17 +1906,7 @@
     lodash "^4.17.11"
     prop-types "^15.6.0"
 
-"@folio/plugin-find-user@*", "@folio/plugin-find-user@^6.0.0":
-  version "6.2.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-user/-/plugin-find-user-6.2.0.tgz#ac7b0c8ae4769e2140c2b098429cfd315db15312"
-  integrity sha512-GxGyzbO6Z/w8hEUcPuSV81ymJq660jhUsep8MbfcGziPbYPwYSALQY7NPp/WFSqfaUP+JcvenOcvsqtqgA4Y0w==
-  dependencies:
-    classnames "^2.2.5"
-    dom-helpers "^3.4.0"
-    lodash "^4.17.4"
-    prop-types "^15.6.0"
-
-"@folio/plugin-find-user@6.1.0":
+"@folio/plugin-find-user@*", "@folio/plugin-find-user@6.1.0", "@folio/plugin-find-user@^6.0.0":
   version "6.1.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-user/-/plugin-find-user-6.1.0.tgz#a08726efe5981dc0e6badae7a091a3e1300f3b10"
   integrity sha512-gpEN9OGpD6ZfXdEfvwV1Z5t9xErnkfZaPs/XJ9/DCWHuDSqcl6HyoqHC3snTfYmQDTDZewsC/L2zYJ1V44xe2Q==
@@ -6143,9 +6075,9 @@ ejs@^2.2.4:
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.210"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.210.tgz#12611fe874b833a3bf3671438b5893aba7858980"
-  integrity sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==
+  version "1.4.211"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz#afaa8b58313807501312d598d99b953568d60f91"
+  integrity sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==
 
 element-is-visible@^1.0.0:
   version "1.0.0"
@@ -13427,9 +13359,9 @@ type@^1.0.1:
   integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
 
 type@^2.5.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.6.1.tgz#808f389ec777205cc3cd97c1c88ec1a913105aae"
-  integrity sha512-OvgH5rB0XM+iDZGQ1Eg/o7IZn0XYJFVrN/9FQ4OWIYILyJJgVP2s1hLTOFn6UOZoDUI/HctGa0PFlE2n2HW3NQ==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.0.tgz#aaff4ac90514e0dc1095b54af70505ef16cf00a2"
+  integrity sha512-NybX0NBIssNEj1efLf1mqKAtO4Q/Np5mqpa57be81ud7/tNHIXn48FDVXiyGMBF90FfXc5o7RPsuRQrPzgMOMA==
 
 typescript@^4.2.4:
   version "4.7.4"


### PR DESCRIPTION
Apps with loose (`*`) optional-deps on plugins allow incompatible
versions of those plugins to leak into the build. Even though the
platform's package.json may depend on `"ui-plugin-find-foo": "3.2.0"`,
if there is an app with a looser dependency that permits a later
version, then the later version will be pulled into the build.

If the later version is incompatible, e.g. because it has a peer
dependency on a stripes-acq-components version that is not present in the
build, this can lead to corruption in the UI (e.g. missing
translations).

The following plugins are included by one or more apps with `*` deps and
therefore have `resolutions` entries here copied directly from their
strict `dependencies` version in order to guarantee that only compatible
versions are included:

* "@folio/plugin-find-contact": "3.1.1",
* "@folio/plugin-find-fund": "1.0.0",
* "@folio/plugin-find-instance": "6.1.6",
* "@folio/plugin-find-interface": "3.1.1",
* "@folio/plugin-find-organization": "3.1.1",
* "@folio/plugin-find-po-line": "3.1.1",
* "@folio/plugin-find-user": "6.1.0",

Refs [FOLIO-3547](https://issues.folio.org/browse/FOLIO-3547)