### PR TITLE
FOLIO-3602 provide additional shared third-party dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for platform-complete
 
+# 2022-R3, Nolana (IN PROGRESS)
+
+* Add additional shared third-party dependencies. Refs FOLIO-3602.
+
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.
 * Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.

--- a/package.json
+++ b/package.json
@@ -76,9 +76,13 @@
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
+    "final-form": "^4.20.7",
+    "final-form-arrays": "^3.0.2",
     "moment": "~2.29.0",
     "react": "~17.0.2",
     "react-dom": "~17.0.2",
+    "react-final-form": "^6.5.9",
+    "react-final-form-arrays": "^3.1.3",
     "react-intl": "^5.25.1",
     "react-query": "^3.13.0",
     "react-redux": "^7.2.2",
@@ -86,8 +90,10 @@
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",
     "redux": "^4.0.5",
+    "redux-observable": "^1.2.0",
     "rxjs": "^6.6.7",
-    "swr": "^0.4.2"
+    "swr": "^0.4.2",
+    "zustand": "^4.1.1"
   },
   "devDependencies": {
     "@folio/stripes-cli": "^2.0.0",


### PR DESCRIPTION
Provide third-party dependencies that stripes and UI applications share so we have a guarantee of compatibility. An identical version is a requirement, enforced by React, in context Provider/Consumer relationships, and while it's possible/probable that you'll get compatible versions when both parties include deps like `^1.2.3`, it's not technically a guarantee.

This also resolves several build warnings for apps that (rightly) expect some of these things to be provided by the platform but in fact they were only being provided directly by other apps and were being hoisted.

The following libraries are being added:

* final-form
* react-final-form
* final-form-arrays
* react-final-form-arrays
* redux-observable
* zustand

Refs [FOLIO-3602](https://issues.folio.org/browse/FOLIO-3602)