### PR TITLE
FOLIO-3610 pin @babel/generator to 7.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for platform-complete
 
+# 2022-R3 (IN PROGRESS)
+
+* Provide `@babel/core` and `@babel/preset-env` dev-deps. Refs FOLIO-3610.
+
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.
 * Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.

--- a/package.json
+++ b/package.json
@@ -90,13 +90,12 @@
     "swr": "^0.4.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
-    "@babel/preset-env": "^7.19.4",
     "@folio/stripes-cli": "^2.0.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {
+    "@babel/generator": "7.19.3",
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
     "swr": "^0.4.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.19.3",
+    "@babel/preset-env": "^7.19.4",
     "@folio/stripes-cli": "^2.0.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"


### PR DESCRIPTION
~This is a bit of a shot in the dark to resolve build failures in CI like the following:~
Pin `@babel/generator` to `7.19.3` to deal with an [NPE regression in 7.19.4](https://github.com/babel/babel/pull/15031).
```
[1m[31mERROR[39m[22m in [1m./node_modules/@folio/finance/src/common/utils/validateDuplicateFieldValue.js[39m[22m
[1mModule build [1m[31mfailed[39m[22m[1m (from ./node_modules/babel-loader/lib/index.js):
TypeError: /home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@folio/finance/src/common/utils/validateDuplicateFieldValue.js: Cannot read property 'start' of undefined
    at Generator._printComments (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/printer.js:667:48)
    at Generator._printLeadingComments (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/printer.js:530:10)
    at Generator.print (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/printer.js:403:10)
    at Generator.printJoin (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/printer.js:479:12)
    at Generator.printList (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/printer.js:554:17)
    at Generator.CallExpression (/home/jenkins/workspace/Automation/build-platform-complete-snapshot/node_modules/@babel/generator/lib/generators/expressions.js:216:8)
```

~See https://stackoverflow.com/questions/52087421/module-build-failed-from-node-modules-babel-loader-lib-index-js-typeerror~

Refs [FOLIO-3610](https://issues.folio.org/browse/FOLIO-3610)