### PR TITLE
FOLIO-3610 pin @babel/generator to 7.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
+    "@babel/generator": "7.19.3",
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "@folio/stripes-webpack": "https://github.com/ualibweb/stripes-webpack#ualibweb/test-ts-loader-node_modules",


### PR DESCRIPTION
Pin to previous @babel/generator release to avoid NPE.

Refs [FOLIO-3610](https://issues.folio.org/browse/FOLIO-3610)