### PR TITLE
MODCXINV-72: removing mod-codex-inventory

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -76,10 +76,6 @@
     "action": "enable"
   },
   {
-    "id": "mod-codex-inventory-2.3.0",
-    "action": "enable"
-  },
-  {
     "id": "mod-codex-ekb-1.10.0",
     "action": "enable"
   },

--- a/install.json
+++ b/install.json
@@ -50,9 +50,6 @@
   "id" : "mod-inventory-update-2.1.0",
   "action" : "enable"
 }, {
-  "id" : "mod-codex-inventory-2.3.0",
-  "action" : "enable"
-}, {
   "id" : "mod-users-18.3.0",
   "action" : "enable"
 }, {

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -32,10 +32,6 @@
     "action": "enable"
   },
   {
-    "id": "mod-codex-inventory-2.3.0",
-    "action": "enable"
-  },
-  {
     "id": "mod-users-18.3.0",
     "action": "enable"
   },


### PR DESCRIPTION
This module has been deprecated, it needs to be removed from all platform builds.