### PR TITLE
FOLIO-3620 bump stripes-erm-components major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 2022-R3, Nolana (IN PROGRESS)
 
 * Add additional shared third-party dependencies. Refs FOLIO-3602.
+* Bump `stripes-erm-components` from `v6` to `v7`. Refs FOLIO-3620.
 
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
-    "@folio/stripes-erm-components": "^7.0.0",
+    "@folio/stripes-erm-components": "folio-org/stripes-erm-components#ERM-2396",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
-    "@folio/stripes-erm-components": "folio-org/stripes-erm-components#ERM-2396",
+    "@folio/stripes-erm-components": "^7.1.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
-    "@folio/stripes-erm-components": "^6.0.0",
+    "@folio/stripes-erm-components": "^7.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",


### PR DESCRIPTION
`@folio/stripes-erm-components` bumped from `v6` to `v7` for 2022-R3 and updated apps' peer-deps accordingly, but forgot to update the version here, which is the only version that actually matters since `yarn` doesn't satisfy peers from deps when building at the platform level (sigh), rather, it only satisfies direct-deps of the platform.

This resolves build warnings like the following when running `yarn install`:
```
warning " > @folio/agreements@8.4.100000461" has incorrect peer dependency "@folio/stripes-erm-components@^7.0.1".
```

Refs [FOLIO-3620](https://issues.folio.org/browse/FOLIO-3620)