### PR TITLE
FOLIO-3634: platform-complete Dockerfile apk upgrade Node and nginx

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.14 as stripes_build
+FROM node:16-alpine as stripes_build
 
 ARG OKAPI_URL=http://localhost:9130
 ARG TENANT_ID=diku
@@ -9,7 +9,11 @@ WORKDIR /etc/folio/stripes
 
 COPY . /etc/folio/stripes/
 
-RUN apk add --no-cache alpine-sdk python3
+RUN apk upgrade \
+ && apk add \
+      alpine-sdk \
+      python3 \
+ && rm -rf /var/cache/apk/*
 RUN yarn config set python /usr/bin/python3
 
 RUN yarn config set @folio:registry https://repository.folio.org/repository/npm-folio/
@@ -19,6 +23,10 @@ RUN yarn build output --okapi $OKAPI_URL --tenant $TENANT_ID
 
 # nginx stage
 FROM nginx:stable-alpine
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade --no-cache
+
 EXPOSE 80
 
 COPY --from=stripes_build /etc/folio/stripes/output /usr/share/nginx/html


### PR DESCRIPTION
Use apk upgrade in
https://github.com/folio-org/platform-complete/blob/master/docker/Dockerfile
to install latest patch versions of packages:
https://pythonspeed.com/articles/security-updates-in-docker/

This will upgrade curl fixing Double Free and Cleartext Transmission of Sensitive Information:
https://www.cve.org/CVERecord?id=CVE-2022-42915
https://www.cve.org/CVERecord?id=CVE-2022-42916
https://security.snyk.io/vuln/SNYK-ALPINE316-CURL-3063711

Replace
`FROM node:lts-alpine3.14 as stripes_build`
by
`FROM node:16-alpine as stripes_build`
because the alpine3.14 is no longer maintained and Node 16 is no longer active LTS. We need Node 16 because postcss-nesting doesn't support Node 18.