### PR TITLE
STRWEB-61 lock enhanced-resolve to 5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add additional shared third-party dependencies. Refs FOLIO-3602.
 * Bump `stripes-erm-components` from `v6` to `v7`. Refs FOLIO-3620.
+* Lock `enhanced-resolve` to `~5.10.0` to avoid the buggy 5.11.0 release. Refs STRWEB-61.
 
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
+    "enhanced-resolve": "~5.10.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
Avoid the buggy 5.11.0 release that appears to be incompatible with webpack-virtual-modules. Additional details at
folio-org/stripes-webpack#81. Locally, locking `enhanced-resolve` in `stripes-webpack` was sufficient to get us to a successful build; alas, CI builds continue to fail because 5.11.0 continues to sneak in 🤨 . 

Refs [STRWEB-61](https://issues.folio.org/browse/STRWEB-61)