### PR TITLE
STRWEB-62: Remove enhanced-resolve resolutions entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add additional shared third-party dependencies. Refs FOLIO-3602.
 * Bump `stripes-erm-components` from `v6` to `v7`. Refs FOLIO-3620.
 * Lock `enhanced-resolve` to `~5.10.0` to avoid the buggy 5.11.0 release. Refs STRWEB-61.
+* Remove `enhanced-resolve` resolutions entry. Refs STRWEB-62.
 
 ## 1.0.0 (IN PROGRESS)
 * Add oai-pmh module. Refs MODOAIPMH-94.

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "@folio/stripes-cli": "^2.4.0",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
-    "enhanced-resolve": "~5.10.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",


### PR DESCRIPTION
https://issues.folio.org/browse/STRWEB-62

This PR removes `enhanced-resolve` resolutions entry since this was fixed directly in webpack: https://github.com/webpack/enhanced-resolve/pull/364