### PR TITLE
Bump version of stripes-erm-components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change history for platform-complete
+# 2023-R1, Orchid (IN PROGRESS)
+* Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
 
 # 2022-R3, Nolana (IN PROGRESS)
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^7.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
-    "@folio/stripes-erm-components": "^7.1.0",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",


### PR DESCRIPTION
stripes-erm-components has moved on to version 8, bump platform complete dependency to reflect that

Refs [ERM-2235](https://issues.folio.org/browse/ERM-2235) and [ERM-2453](https://issues.folio.org/browse/ERM-2453)