### PR TITLE
FOLIO-3683 MODDICONV-259 Rename mod-data-import-converter-storage mod-di-converter-storage

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -56,7 +56,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-data-import-converter-storage",
+    "id": "mod-di-converter-storage",
     "action": "enable"
   },
   {


### PR DESCRIPTION
[MODDICONV-259](https://issues.folio.org/browse/MODDICONV-259)
[FOLIO-3683](https://issues.folio.org/browse/FOLIO-3683)

The new [ModuleDescriptor](https://github.com/folio-org/mod-di-converter-storage/blob/master/descriptors/ModuleDescriptor-template.json) utilises the "replace" facility, and retains the same interface name and version.