### PR TITLE
bump @folio/stripes to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Change history for platform-complete
 # 2023-R1, Orchid (IN PROGRESS)
-* Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
 
-# 2022-R3, Nolana (IN PROGRESS)
+* Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
+* Bump `stripes` to `8.0.0`. Refs STCOM-1067, STSMACOM-1067, STCOR-663, et al.
+
+# 2022-R3, Nolana
 
 * Add additional shared third-party dependencies. Refs FOLIO-3602.
 * Bump `stripes-erm-components` from `v6` to `v7`. Refs FOLIO-3620.
 * Lock `enhanced-resolve` to `~5.10.0` to avoid the buggy 5.11.0 release. Refs STRWEB-61.
 * Remove `enhanced-resolve` resolutions entry. Refs STRWEB-62.
 
-## 1.0.0 (IN PROGRESS)
+## 1.0.0
 * Add oai-pmh module. Refs MODOAIPMH-94.
 * Add `ui-plugin-create-inventory-records` to the list of dependencies and modules.
 * Update `react-intl` to `^5.7.0`, STRIPES-694

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@folio/serials-management": ">=1.0.0",
     "@folio/service-interaction": ">=1.0.0",
     "@folio/servicepoints": ">=1.1.0",
-    "@folio/stripes": "^7.0.0",
+    "@folio/stripes": "^8.0.0",
     "@folio/stripes-authority-components": "^1.0.0",
     "@folio/stripes-erm-components": "^8.0.0",
     "@folio/tags": ">=1.1.0",
@@ -102,7 +102,7 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "@folio/stripes-cli": "^2.4.0",
+    "@folio/stripes-cli": "^2.6.1",
     "@rehooks/local-storage": "2.4.0",
     "colors": "1.4.0",
     "final-form": "^4.20.4",


### PR DESCRIPTION
The 2023-R1/Orchid release of stripes and its constituent libraries will contain breaking changes, including the removal of many props that have long been deprecated.