### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change history for platform-complete
 
-## 3.9.0 (IN PROGRESS)
+## 4.0.0 (IN PROGRESS)
 * `yarn install` now runs with `--ignore-scripts` by default, which prevents packages from running scripts after install. Only one case is currently needed for `stripes-core` to build icons, so a post-install step has been added to invoke that automatically.
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/platform-complete",
-  "version": "3.9.0",
+  "version": "4.0.0",
   "license": "Apache-2.0",
   "scripts": {
     "build": "export NODE_OPTIONS=\"--max-old-space-size=4096 $NODE_OPTIONS\"; stripes build stripes.config.js",
@@ -82,7 +82,7 @@
     "react-final-form-arrays": "^3.1.3",
     "react-intl": "^5.25.1",
     "react-query": "^3.13.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STRIPES-834.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.