### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 * Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
 * Bump `stripes` to `8.0.0`. Refs STCOM-1067, STSMACOM-1067, STCOR-663, et al.
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
 
 # 2022-R3, Nolana
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-final-form-arrays": "^3.1.3",
     "react-intl": "^5.25.1",
     "react-query": "^3.13.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STRIPES-834.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.