### PR TITLE
STCOR-611 remove swr cruft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
 * Bump `stripes` to `8.0.0`. Refs STCOM-1067, STSMACOM-1067, STCOR-663, et al.
 * Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+* Remove `swr`. Refs STCOR-611.
 
 # 2022-R3, Nolana
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "redux": "^4.0.5",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.7",
-    "swr": "^0.4.2",
     "zustand": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Implementing swr was a [POC](https://issues.folio.org/browse/STCOR-516); we chose react-query instead. 

Refs [STCOR-611](https://issues.folio.org/browse/STCOR-611)