### PR TITLE
MODGQL-165 Pin mod-graphql to previous

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -84,7 +84,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-graphql",
+    "id": "mod-graphql-1.10.2000317",
     "action": "enable"
   },
   {


### PR DESCRIPTION
The hourly builds are too broken. Pin to previous working 1.10.2000317, while a fix is prepared.
[MODGQL-165](https://issues.folio.org/browse/MODGQL-165)