### PR TITLE
update versions for stripes v8 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Change history for platform-complete
-# 2023-R1, Orchid (IN PROGRESS)
 
-* Bump `stripes-erm-components` from `v7` to `v8`. Refs ERM-2235 and ERM-2453
+# 2023-R2, Poppy (IN PROGRESS)
+
+# 2023-R1, Orchid
+
+* Bump `stripes-erm-components` to `v8`. Refs ERM-2235 and ERM-2453
 * Bump `stripes` to `8.0.0`. Refs STCOM-1067, STSMACOM-1067, STCOR-663, et al.
 * Upgrade `react-redux` to `v8`. Refs STRIPES-834.
 * Remove `swr`. Refs STCOR-611.
-* Bump `stripes-authority-components`. Refs UISAUTCOMP-37
+* Bump `stripes-authority-components` to `v2`. Refs UISAUTCOMP-37.
+* Bump `stripes-cli` to `^2.7.0`. Refs STCLI-227.
+* Bump `@rehooks/local-storage` to `^2.4.4`. Refs STRIPES-839.
 
 # 2022-R3, Nolana
 

--- a/package.json
+++ b/package.json
@@ -96,13 +96,12 @@
     "zustand": "^4.1.1"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^2.0.0",
+    "@folio/stripes-cli": "^2.7.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "@folio/stripes-cli": "^2.6.1",
-    "@rehooks/local-storage": "2.4.0",
+    "@rehooks/local-storage": "2.4.4",
     "colors": "1.4.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",


### PR DESCRIPTION
* Bump `stripes-cli` to `^2.7.0`. Refs [STCLI-227](https://issues.folio.org/browse/STCLI-227).
* Bump `@rehooks/local-storage` to `^2.4.4`. Refs [STRIPES-839](https://issues.folio.org/browse/STRIPES-839).