### PR TITLE
STRIPES-860 align redux semver with in-use version

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",
-    "redux": "^4.0.5",
+    "redux": "^4.2.1",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.7",
     "zustand": "^4.1.1"


### PR DESCRIPTION
Set the minimum version of `redux` to the version currently in use (`4.2.1`) as part of coordinating the version across all repositories.

Note that there is *zero* impact from this change; all it does it align the minimum version being requested with the current version already in-use.

Refs [STRIPES-860](https://issues.folio.org/browse/STRIPES-860)