### PR TITLE
FOLIO-3768 do not rebuild yarn.lock from scratch for hotfixes on rele…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,10 +65,13 @@ pipeline {
             echo "Okapi URL: ${env.okapiUrl}"
             echo "Tenant: ${env.tenant}"
 
-            // Remove existing .yarnrc on build image for release builds.
-            // Use repo configuration.
-            sh 'rm -f /home/jenkins/.yarnrc'
-            buildStripesPlatform(env.okapiUrl,env.tenant)
+            script {
+              // Remove existing .yarnrc on build image for release builds.
+              // Use repo configuration
+              sh 'rm -f /home/jenkins/.yarnrc'
+              def branch = env.CHANGE_TARGET?.trim() ? env.CHANGE_TARGET : env.BRANCH_NAME
+              buildStripesPlatform(env.okapiUrl, env.tenant, branch)
+            }
           }
         }
 


### PR DESCRIPTION
Instead of rebuilding yarn.lock files from scratch for hotfixes on release branches, we should retain yarn.lock from the previous release and only include new versions of third-party libraries that are a direct result of updating versions in package.json.

!Merge ONLY after: https://github.com/folio-org/jenkins-pipeline-libs/pull/151