### PR TITLE
STRIPES-870 bump react to v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 2023-R2, Poppy (IN PROGRESS)
 
+* Bump `react` to `^18.2.0`, `stripes` to `^9.0.0`, `stripes-cli` to `3.0.0`. Refs STRIPES-870.
+
 # 2023-R1, Orchid
 
 * Bump `stripes-erm-components` to `v8`. Refs ERM-2235 and ERM-2453

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@folio/serials-management": ">=1.0.0",
     "@folio/service-interaction": ">=1.0.0",
     "@folio/servicepoints": ">=1.1.0",
-    "@folio/stripes": "^8.0.0",
+    "@folio/stripes": "^9.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
     "@folio/stripes-erm-components": "^8.0.0",
     "@folio/tags": ">=1.1.0",
@@ -80,8 +80,8 @@
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",
     "moment": "~2.29.0",
-    "react": "~17.0.2",
-    "react-dom": "~17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
     "react-intl": "^5.25.1",
@@ -96,7 +96,7 @@
     "zustand": "^4.1.1"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^2.7.0",
+    "@folio/stripes-cli": "^3.0.0",
     "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },


### PR DESCRIPTION
* Bump `react` to `v18`, and correspondingly `@folio/stripes` to `v9` and `@folio/stripes-cli` to `v3`.

Refs [STRIPES-870](https://issues.folio.org/browse/STRIPES-870)