### PR TITLE
ERM-2989 bump stripes-erm-components to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 2023-R2, Poppy (IN PROGRESS)
 
 * Bump `react` to `^18.2.0`, `stripes` to `^9.0.0`, `stripes-cli` to `3.0.0`. Refs STRIPES-870.
+* Bump `stripes-erm-components` to `^9.0.0`. Refs ERM-2989.
 
 # 2023-R1, Orchid
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^9.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
-    "@folio/stripes-erm-components": "^8.0.0",
+    "@folio/stripes-erm-components": "^9.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",


### PR DESCRIPTION
Bump `stripes-erm-components` to `^8.0.0` for stripes v9 and react v18 compat.

Refs [ERM-2989](https://issues.folio.org/browse/ERM-2989)