### PR TITLE
UISAQCOMP-160 lock react-virtualized-auto-sizer to 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change history for platform-complete
 
+# 2023-R1 Orchid SP 6
+
+* Pin `react-virtualized-auto-sizer` to `v1.0.7`, preserving CSS behavior of `<Pane>` Actions menus. Refs UISACQCOMP-160.
+
 ## 3.9.0 (IN PROGRESS)
 * `yarn install` now runs with `--ignore-scripts` by default, which prevents packages from running scripts after install. Only one case is currently needed for `stripes-core` to build icons, so a post-install step has been added to invoke that automatically.

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.1",
+    "react-virtualized-auto-sizer": "1.0.7",
     "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
Lock `react-virtualized-auto-sizer` to `v1.0.7` to preserve the CSS behavior of `<Pane>` related to the "Actions" menu. RVAS >= `v1.0.8` substantially reworked its internal structure, changing the way it interacts with `<Pane>`, a bug described in detail in STCOM-1148.

Avoiding the update or changing our CSS are both viable approaches to resolving the problem. Given `stripes-components` already takes the former approach in its Orchid-compatible release (v11.0.4), we are taking the same approach here.

Refs [UISACQCOMP-160](https://issues.folio.org/browse/UISACQCOMP-160), [STCOM-1148](https://issues.folio.org/browse/STCOM-1148), [STCOM-1146](https://issues.folio.org/browse/STCOM-1146)