### PR TITLE
Bump react-titled to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump `react` to `^18.2.0`, `stripes` to `^9.0.0`, `stripes-cli` to `3.0.0`. Refs STRIPES-870.
 * Bump `stripes-erm-components` to `^9.0.0`. Refs ERM-2989.
 * Bump `react-intl` to `^6.4.4`. Refs STRIPES-868.
+* Bump `react-titled` to `^2.0.0`.
 
 # 2023-R1, Orchid
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-titled": "^1.0.1",
+    "react-titled": "^2.0.0",
     "redux": "^4.2.1",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.7",


### PR DESCRIPTION
Bump `react-titled` to v2 in order to align with the version already provided by `@folio/stripes`. v2 provides react v18 compatibility, among other modernizations. This is less "make an upgrade" than "make the platform's version consistent with the upgrade that has already taken place in applications."