### PR TITLE
FOLIO-3768 restore intentional R1-2023 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,11 +101,11 @@
     "colors": "1.4.0",
     "@folio/stripes-cli": "^2.4.0",
     "@folio/stripes-webpack": "4.2.1",
-    "@rehooks/local-storage": "2.4.5",
-    "final-form": "^4.20.4",
-    "minimist": "^1.2.3",
-    "moment": "~2.29.1",
-    "react-virtualized-auto-sizer": "1.0.20",
-    "redux-form": "^8.0.0"
+    "@rehooks/local-storage": "2.4.4",
+    "final-form": "4.20.9",
+    "minimist": "1.2.8",
+    "moment": "2.29.4",
+    "react-virtualized-auto-sizer": "1.0.7",
+    "redux-form": "8.3.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,10 +2759,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
-"@rehooks/local-storage@2.4.0", "@rehooks/local-storage@2.4.4", "@rehooks/local-storage@2.4.5", "@rehooks/local-storage@^2.4.4":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.5.tgz#92c773ce623e168274557499679582cd32749f77"
-  integrity sha512-3Q4KtiUBaKoIDRK72BWfAy50ul6hbw29f/M7tyCzlMe2FbSsiQNok0WGeBLaYj4T2PJ7JMSJlSbUGY8RNsImmw==
+"@rehooks/local-storage@2.4.0", "@rehooks/local-storage@2.4.4", "@rehooks/local-storage@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.4.tgz#ccf40f60c2dcbab86dc88f9e3ea898d1fb8bea2d"
+  integrity sha512-zE+kfOkG59n/1UTxdmbwktIosclr67Nlbf2MzUJ9mNtCSypVscNHeD1qT6JCSo5Pjj8DO893IKWNLJqKKzDL/Q==
 
 "@restart/hooks@^0.3.25":
   version "0.3.27"
@@ -5604,7 +5604,7 @@ final-form-set-field-data@^1.0.2:
   resolved "https://registry.yarnpkg.com/final-form-set-field-data/-/final-form-set-field-data-1.0.2.tgz#ce19095af5d607148c1e6ce3403d75d40223d848"
   integrity sha512-gAnENimyQ5GW3OEGca5pbwm4lYshW2orzfBlPUYqzcm7ZxkQrVO8FqCAgEcCM+Rq9U1OU0q+D+UkqETvvDY6jw==
 
-final-form@^4.18.2, final-form@^4.18.4, final-form@^4.18.5, final-form@^4.18.7, final-form@^4.19.0, final-form@^4.19.1, final-form@^4.20.1, final-form@^4.20.4, final-form@^4.20.7:
+final-form@4.20.9, final-form@^4.18.2, final-form@^4.18.4, final-form@^4.18.5, final-form@^4.18.7, final-form@^4.19.0, final-form@^4.19.1, final-form@^4.20.1, final-form@^4.20.7:
   version "4.20.9"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.9.tgz#647b459f8c504d77ec8f6e280015ab172982af2f"
   integrity sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==
@@ -7689,7 +7689,7 @@ minimatch@~3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@1.2.8, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -7796,7 +7796,7 @@ moment-timezone@^0.5.14, moment-timezone@^0.5.17, moment-timezone@^0.5.20, momen
   dependencies:
     moment "^2.29.4"
 
-moment@^2.10.2, moment@^2.25.3, moment@^2.29.1, moment@^2.29.4, moment@~2.29.0, moment@~2.29.1, moment@~2.29.4:
+moment@2.29.4, moment@^2.10.2, moment@^2.25.3, moment@^2.29.1, moment@^2.29.4, moment@~2.29.0, moment@~2.29.4:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
@@ -9380,10 +9380,10 @@ react-transition-group@^2.2.1, react-transition-group@^2.4.0:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-virtualized-auto-sizer@1.0.20, react-virtualized-auto-sizer@1.0.7, react-virtualized-auto-sizer@^1.0.2, react-virtualized-auto-sizer@^1.0.6:
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz#d9a907253a7c221c52fa57dc775a6ef40c182645"
-  integrity sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==
+react-virtualized-auto-sizer@1.0.7, react-virtualized-auto-sizer@^1.0.2, react-virtualized-auto-sizer@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.7.tgz#bfb8414698ad1597912473de3e2e5f82180c1195"
+  integrity sha512-Mxi6lwOmjwIjC1X4gABXMJcKHsOo0xWl3E3ugOgufB8GJU+MqrtY35aBuvCYv/razQ1Vbp7h1gWJjGjoNN5pmA==
 
 react-window@^1.8.5:
   version "1.8.9"
@@ -9440,7 +9440,7 @@ redux-actions@^2.2.1:
     reduce-reducers "^0.4.3"
     to-camel-case "^1.0.0"
 
-redux-form@^8.0.0, redux-form@^8.3.0, redux-form@^8.3.7:
+redux-form@8.3.10, redux-form@^8.0.0, redux-form@^8.3.0, redux-form@^8.3.7:
   version "8.3.10"
   resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-8.3.10.tgz#335657fafd4b26b91b4ce65371cd9dabe3648158"
   integrity sha512-Eeog8dJYUxCSZI/oBoy7VkprvMjj1lpUnHa3LwjVNZvYDNeiRZMoZoaAT+6nlK2YQ4aiBopKUMiLe4ihUOHCGg==


### PR DESCRIPTION
renovate is a super helpful tool, but it must not make changes to the versions we specify in `resolutions`. Recent changes (#2469, #2459) updated fixed versions and reintroduced old bugs (STCOM-1148, and a node incompatibility since `@rehooks/local-storage` `2.4.5` wants `v18` but something else relies on `v16`).

This PR restores the original versions of both `react-virtualized-auto-sizer` (aka RVAS) and `@rehooks/local-storage` and removes the semver flexibility (`~` or `^`) of other third-party dependencies in `resolutions` in case we figure out how to configure renovate to always leave fixed versions as-is. 

Refs [FOLIO-3768](https://issues.folio.org/browse/FOLIO-3768)