### PR TITLE
STCOR-761 preserve console log on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for platform-complete
 
+# 2024-R1, Ramsons
+
+* Preserve console log on logout, at least for reference envs. Refs STCOR-761.
+
 # 2023-R2, Poppy (IN PROGRESS)
 
 * Bump `react` to `^18.2.0`, `stripes` to `^9.0.0`, `stripes-cli` to `3.0.0`. Refs STRIPES-870.

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -8,7 +8,8 @@ module.exports = {
     logCategories: 'core,path,action,xhr',
     logPrefix: '--',
     maxUnpagedResourceCount: 2000,
-    showPerms: false
+    showPerms: false,
+    preserveConsole: true,
   },
 
   modules: {


### PR DESCRIPTION
Do not clear the console log on logout. This is less secure, but in a test environment it may help with debugging.

Refs [STCOR-761](https://issues.folio.org/browse/STCOR-761)