### PR TITLE
STCOR-671 use secure tokens (RTR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change history for platform-complete
 
-# 2024-R1, Ramsons
+# 2024-R1, Quesnelia
 
 * Preserve console log on logout, at least for reference envs. Refs STCOR-761.
+* Use secure tokens in cookies (RTR). Refs STCOR-671.
 
 # 2023-R2, Poppy (IN PROGRESS)
 

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -10,6 +10,7 @@ module.exports = {
     maxUnpagedResourceCount: 2000,
     showPerms: false,
     preserveConsole: true,
+    useSecureTokens: true,
   },
 
   modules: {


### PR DESCRIPTION
Set `useSecureTokens: true` in `stripes.config.js` to turn on RTR.

See also folio-org/stripes-core/pull/1376

Refs [STCOR-671](https://issues.folio.org/browse/STCOR-671), [FOLIO-3627](https://issues.folio.org/browse/FOLIO-3627)