### PR TITLE
FOLIO-3993 Add optional login-saml interface

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -124,6 +124,10 @@
     "action": "enable"
   },
   {
+    "id": "mod-login-saml",
+    "action": "enable"
+  },
+  {
     "id": "mod-marc-migrations",
     "action": "enable"
   },


### PR DESCRIPTION
- Fulfills [FOLIO-3993](https://folio-org.atlassian.net/browse/FOLIO-3993)
- `mod-login-saml` has been marked as optional by https://github.com/folio-org/ui-tenant-settings/pull/391, but we would still like it to be included in community snapshot builds. Since it was automatically dropped when marked optional, re-adding it through `install-extras.json`.