### PR TITLE
FOLIO-3997 omit unnecessary favicons, sharp dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,8 +107,6 @@
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
-    "redux-form": "^8.0.0",
-    "favicons": "7.1.5",
-    "sharp": "0.32.6"
+    "redux-form": "^8.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,13 +5921,13 @@ favicons-webpack-plugin@^6.0.0:
   optionalDependencies:
     html-webpack-plugin "^5.5.0"
 
-favicons@7.1.4, favicons@7.1.5:
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/favicons/-/favicons-7.1.5.tgz#ce7b63ba3a0f62229ff3459be2421c1a610da152"
-  integrity sha512-OVqWHqVnxGmvcQdXGmA9wGkfiZTrgaaVNvoeemzrV1YHP/boAyGJVRFGwib5NxLm+sQmJrf2MuRaJX33sJkMVw==
+favicons@7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/favicons/-/favicons-7.1.4.tgz#bc0ed1a8d752f94a36912294681925e272d25ff0"
+  integrity sha512-lnZpVgT7Fzz+DUjioKF1dMwLYlpqWCaB4gIksIfIKwtlhHO1Q7w23hERwHQjEsec+43iENwbTAPRDW3XvpLhbg==
   dependencies:
     escape-html "^1.0.3"
-    sharp "^0.33.1"
+    sharp "^0.32.4"
     xml2js "^0.6.1"
 
 fflate@^0.4.8:
@@ -10044,7 +10044,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@0.32.6, sharp@^0.33.1:
+sharp@^0.32.4:
   version "0.32.6"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
   integrity sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==


### PR DESCRIPTION
`favicons` and `sharp` were added to resolutions in #2644, probably to avoid pulling `favicons` `7.1.5` in a build that was running without a `yarn.lock` file before `@folio/stripes-webpack` `5.1.0` was published (which similarly locks it to `v7.1.4`), but then dependabot updated in PR #2645. Whoops. Bad dependabot. No biscuit! We depended on that specific version because we wanted that specific version.

Refs [FOLIO-3997](https://folio-org.atlassian.net/browse/FOLIO-3997), [STRWEB-105](https://folio-org.atlassian.net/browse/STRWEB-105)