### PR TITLE
FOLIO-4030 bump zustand to ^4.5.4 to avoid buggy 4.5.3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "redux": "^4.2.1",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.7",
-    "zustand": "^4.1.1"
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@folio/stripes-cli": "^3.0.0",
@@ -107,7 +107,6 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
-    "zustand": "4.5.2",
     "@rehooks/local-storage": "2.4.4",
     "colors": "1.4.0",
     "final-form": "^4.20.4",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
+    "zustand": "4.5.2",
     "@rehooks/local-storage": "2.4.4",
     "colors": "1.4.0",
     "final-form": "^4.20.4",


### PR DESCRIPTION
Bump zustand from `^4.1.1` to `^4.5.4` to avoid the buggy `v4.5.3` release (https://github.com/pmndrs/zustand/discussions/2621).

Builds with v4.5.3 fail:
```
ERROR in ./node_modules/zustand/esm/index.js 1:0
Module parse failed: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> import { createStore } from 'zustand/vanilla';
| export * from 'zustand/vanilla';
| import ReactExports from 'react';
```

Refs [FOLIO-4030](https://folio-org.atlassian.net/browse/FOLIO-4030)