### PR TITLE
FOLIO-4029 Update install-extras.json to request mod-login and mod-authtoken

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -174,6 +174,12 @@
   {
     "id": "mod-audit",
     "action": "enable"
-  }
+  },
+  {
+    "id": "mod-login",
+    "action": "enable"
+  },
+  {
+    "id": "mod-authtoken",
+    "action": "enable"
 ]
-

--- a/install-extras.json
+++ b/install-extras.json
@@ -182,4 +182,5 @@
   {
     "id": "mod-authtoken",
     "action": "enable"
+  }
 ]


### PR DESCRIPTION
This is to prevent the Keycloak-integrated modules that offer the same interfaces from causing an error in building platform-complete or in building a reference environment. FOLIO-4029.