### PR TITLE
FOLIO-3994 Add mod-ldp to snapshot install-extras.json

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -186,5 +186,9 @@
   {
     "id": "mod-authtoken",
     "action": "enable"
+  },
+  {
+    "id": "mod-ldp",
+    "action": "enable"
   }
 ]


### PR DESCRIPTION
Cater for multiple interfaces upcoming mod-reporting. Needed while testing new Workflows ModuleDescriptor.