### PR TITLE
FOLIO-4061 pin typescript to 5.5, avoiding breaking changes in 5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lodash": "^4.17.5"
   },
   "resolutions": {
+    "typescript": "~5.5",
     "@rehooks/local-storage": "2.4.4",
     "colors": "1.4.0",
     "final-form": "^4.20.4",


### PR DESCRIPTION
Typescript doesn't believe in semver and published breaking changes between v5.5.4 and v5.6.2. Pinning to v5.6.4, the last-known-compatible version, here in the platform will allow our builds to get back on track while we investigate if/how/when to pursue compatibility with v5.6.

Refs [FOLIO-4061](https://folio-org.atlassian.net/browse/FOLIO-4061)