### PR TITLE
FOLIO-4160: Enable mod-authtoken early (master)

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -4,6 +4,14 @@
     "action": "enable"
   },
   {
+    "id": "mod-users-19.4.0",
+    "action": "enable"
+  },
+  {
+    "id": "mod-authtoken-2.16.1",
+    "action": "enable"
+  },
+  {
     "id": "edge-connexion-1.3.1",
     "action": "enable"
   },
@@ -73,10 +81,6 @@
   },
   {
     "id": "mod-email-1.18.0",
-    "action": "enable"
-  },
-  {
-    "id": "mod-users-19.4.0",
     "action": "enable"
   },
   {
@@ -249,10 +253,6 @@
   },
   {
     "id": "mod-quick-marc-6.0.0",
-    "action": "enable"
-  },
-  {
-    "id": "mod-authtoken-2.16.1",
     "action": "enable"
   },
   {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4160

Move mod-authtoken to the top so that it gets installed early.

Then it is available when enabling a second module that requires a token to access a permission protected API of a third module.

Modules using authtokens don't have the authtoken okapi interface in their requires section of in their module descriptor because they don't use the mod-authtoken HTTP API but the token feature of Okapi. Therefore we need to use the install order to ensure mod-authtoken availability.

https://folio-project.slack.com/archives/CFQU1MF61/p1725977004958399?thread_ts=1725933118.184429&cid=CFQU1MF61

mod-authtoken requires mod-permissions and mod-users therefore we use this natural order:
1. mod-permissions
2. mod-users
3. mod-authtoken