### PR TITLE
STCOR-875 UIU-3183 use default branches of stripes-core, ui-users

### DIFF
--- a/eureka-tpl/package.json
+++ b/eureka-tpl/package.json
@@ -84,7 +84,7 @@
     "@folio/stripes-marc-components": ">=1.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
-    "@folio/users": "folio-org/ui-users#keycloak-ramsons",
+    "@folio/users": ">=2.17.0",
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",
     "moment": "~2.29.0",
@@ -115,7 +115,6 @@
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
-    "redux-form": "^8.0.0",
-    "@folio/stripes-core": "folio-org/stripes-core#keycloak-ramsons"
+    "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
Subsequent to STCOR-875 and UIU-3183, Eureka UI work will be part of the mainline in all UI repositories and thus does not require special handling in `package.json` any longer.

Refs [STCOR-875](https://folio-org.atlassian.net/browse/STCOR-875), [UIU-3183](https://folio-org.atlassian.net/browse/UIU-3183)