### PR TITLE
resolve @types/react to v18 to avoid v19 leaking in

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
   "resolutions": {
     "typescript": "~5.5",
     "@rehooks/local-storage": "2.4.4",
+    "@types/react": "^18.3.14",
     "colors": "1.4.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",


### PR DESCRIPTION
Many packages published by DefinitelyTyped use loose dependencies like
```
"@types/react": "*",
```
allowing non-compliant types from react v19 to leak into our v18-based build.