### PR TITLE
Pin mod-licenses and mod-service-interaction to specific builds.

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -186,5 +186,13 @@
   {
     "id": "mod-login",
     "action": "enable"
+  },
+  {
+    "id": "mod-licenses-6.2.0-SNAPSHOT.268",
+    "action": "enable"
+  },
+  {
+    "id": "mod-service-interaction-4.2.0-SNAPSHOT.129",
+    "action": "enable"
   }
 ]


### PR DESCRIPTION
Avoid pulling in mod-okapi-facade.