### PR TITLE
Specify "okapi" module in install-extras.json

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -1,5 +1,9 @@
 [
   {
+    "id": "okapi",
+    "action": "enable"
+  },
+  {
     "id": "mod-permissions",
     "action": "enable"
   },

--- a/install-extras.json
+++ b/install-extras.json
@@ -190,13 +190,5 @@
   {
     "id": "mod-login",
     "action": "enable"
-  },
-  {
-    "id": "mod-licenses-6.2.0-SNAPSHOT.268",
-    "action": "enable"
-  },
-  {
-    "id": "mod-service-interaction-4.2.0-SNAPSHOT.129",
-    "action": "enable"
   }
 ]


### PR DESCRIPTION
Because mod-okapi-facade now offers the `okapi` interface, the "okapi" module must be specified for Okapi-based builds to prevent mod-okapi-facade from being pulled in by dependency resolution.

Also remove pinning of mod-licenses and mod-service-interaction to versions that don't require the `okapi` interface.

FOLIO-4169