### PR TITLE
STRIPES-960 STRIPES-961 update react-intl, stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Change history for platform-complete
 
+# 2025-R1, Sunflower
+
+* Bump `react-intl` to `^7`. Refs STRIPES-960.
+* Bump `@folio/stripes` to `^10`. Refs STRIPES-961.
+
+# 2024-R2, Ramsons
+
 # 2024-R1, Quesnelia
 
 * Preserve console log on logout, at least for reference envs. Refs STCOR-761.
 * Use secure tokens in cookies (RTR). Refs STCOR-671.
 
-# 2023-R2, Poppy (IN PROGRESS)
+# 2023-R2, Poppy 
 
 * Bump `react` to `^18.2.0`, `stripes` to `^9.0.0`, `stripes-cli` to `3.0.0`. Refs STRIPES-870.
 * Bump `stripes-erm-components` to `^9.0.0`. Refs ERM-2989.

--- a/package.json
+++ b/package.json
@@ -75,8 +75,9 @@
     "@folio/serials-management": ">=1.0.0",
     "@folio/service-interaction": ">=1.0.0",
     "@folio/servicepoints": ">=1.1.0",
-    "@folio/stripes": "^9.0.0",
+    "@folio/stripes": "^10.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
+    "@folio/stripes-cli": "^4.0.0",
     "@folio/stripes-erm-components": "^9.0.0",
     "@folio/stripes-inventory-components": ">=1.0.0",
     "@folio/stripes-marc-components": ">=1.0.0",
@@ -90,7 +91,7 @@
     "react-dom": "^18.2.0",
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-query": "^3.13.0",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
@@ -102,9 +103,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^3.0.0",
     "@types/lodash": "^4.14.197",
-    "eslint": "^6.2.1",
     "lodash": "^4.17.5"
   },
   "resolutions": {


### PR DESCRIPTION
* update `react-intl` to v7
* update `@folio/stripes` to v10
* move `@folio/stripes-cli` into dependencies, where it has always belonged
* removed unused dev-deps (probably they can all be removed but this requires more investigation and testing)

Refs [STRIPES-960](https://folio-org.atlassian.net/browse/STRIPES-960), [STRIPES-961](https://folio-org.atlassian.net/browse/STRIPES-961)

