### PR TITLE
FOLIO-4255 build with stripes-build instead of stripes-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump `react-intl` to `^7`. Refs STRIPES-960.
 * Bump `@folio/stripes` to `^10`. Refs STRIPES-961.
 * Order user-visible apps alphabetically by title in `stripes.config.js`. Refs FOLIO-4245. 
+* Include `@folio/stripes-build` as a direct-dep; `@folio/stripes-cli` as a dev-dep.
 
 # 2024-R2, Ramsons
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,11 @@
   "version": "1.1.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "export NODE_OPTIONS=\"--max-old-space-size=8000 $NODE_OPTIONS\"; stripes build stripes.config.js",
-    "stripes": "stripes",
+    "build": "export NODE_OPTIONS=\"--max-old-space-size=8000 $NODE_OPTIONS\"; stripes-build build stripes.config.js",
     "start": "stripes serve stripes.config.js",
-    "build-module-descriptors": "stripes mod descriptor stripes.config.js --output ./ModuleDescriptors",
+    "build-module-descriptors": "stripes-build mod descriptor stripes.config.js --full --strict  --output ./ModuleDescriptors",
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
-    "test": "echo 'No unit tests implemented'",
-    "test-int": "stripes test nightmare stripes.config.js",
-    "test-regression": "stripes test nightmare stripes.config.js --run WD/platform-core/checkout/users/inventory/requests/circulation/tenant-settings"
+    "test": "echo 'No unit tests implemented'"
   },
   "dependencies": {
     "@folio/acquisition-units": ">=1.0.0",
@@ -77,15 +74,17 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^10.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
-    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-build": "^1.0.0",
     "@folio/stripes-erm-components": "^9.0.0",
     "@folio/stripes-inventory-components": ">=1.0.0",
     "@folio/stripes-marc-components": ">=1.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
+    "@types/lodash": "^4.14.197",
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",
+    "lodash": "^4.17.5",
     "moment": "~2.29.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -103,8 +102,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@types/lodash": "^4.14.197",
-    "lodash": "^4.17.5"
+    "@folio/stripes-cli": "^4.0.0"
   },
   "resolutions": {
     "typescript": "~5.5",


### PR DESCRIPTION
* Provide `@folio/stripes-build` as a direct-dep instead of `@folio/stripes-cli` (now moved to a dev-dep), in order to provide a streamlined build in a production environment. `@folio/stripes-build` is a stripped-down version of `@folio/stripes-cli` with drastically fewer dependencies and thus a smaller surface area for security vulnerabilities. On release branches, `@folio/stripes-cli` can/should be removed entirely. 
* Clean up test script cruft.



Refs [FOLIO-4255](https://folio-org.atlassian.net/browse/FOLIO-4255)