### PR TITLE
FOLIO-4262 bump react-intl to ^7.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bump `@folio/stripes` to `^10`. Refs STRIPES-961.
 * Order user-visible apps alphabetically by title in `stripes.config.js`. Refs FOLIO-4245. 
 * Include `@folio/stripes-build` as a direct-dep; `@folio/stripes-cli` as a dev-dep.
+* Bump `react-intl` to `^7.1.9`. Refs FOLIO-4262.
 
 # 2024-R2, Ramsons
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^18.2.0",
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
-    "react-intl": "^7.1.5",
+    "react-intl": "^7.1.9",
     "react-query": "^3.13.0",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
@@ -102,7 +102,6 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^4.0.0"
   },
   "resolutions": {
     "typescript": "~5.5",


### PR DESCRIPTION
Bump `react-intl` to `^7.1.9` to avoid https://github.com/formatjs/formatjs/issues/4915.

Refs [FOLIO-4262](https://folio-org.atlassian.net/browse/FOLIO-4262)