### PR TITLE
FOLIO-4263 bump react-intl to ^7.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 2025-R1, Sunflower
 
-* Bump `react-intl` to `^7`. Refs STRIPES-960.
+* Bump `react-intl` to `^7`. Refs STRIPES-960 (and FOLIO-4262, FOLIO-4263).
 * Bump `@folio/stripes` to `^10`. Refs STRIPES-961.
 * Order user-visible apps alphabetically by title in `stripes.config.js`. Refs FOLIO-4245. 
 * Include `@folio/stripes-build` as a direct-dep; `@folio/stripes-cli` as a dev-dep.

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^18.2.0",
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
-    "react-intl": "^7.1.9",
+    "react-intl": "^7.1.10",
     "react-query": "^3.13.0",
     "react-redux": "^8.0.5",
     "react-router": "^5.2.0",


### PR DESCRIPTION
It turns out #3272 had the right idea but was a bit too soon as react-intl v7.1.9 was still broken,
https://github.com/formatjs/formatjs/issues/4918.

Refs [FOLIO-4263](https://folio-org.atlassian.net/browse/FOLIO-4263)