### PR TITLE
restore @folio/stripes-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
+    "@folio/stripes-cli": "^4.0.0"
   },
   "resolutions": {
     "typescript": "~5.5",


### PR DESCRIPTION
`@folio/stripes-cli` was inadvertently removed in #3272. Bad developer! No biscuit!