### PR TITLE
Update @folio/calendar to 12.0.0

### DIFF
--- a/install.json
+++ b/install.json
@@ -128,7 +128,7 @@
   "id" : "mod-calendar-3.3.0",
   "action" : "enable"
 }, {
-  "id" : "folio_calendar-11.0.3",
+  "id" : "folio_calendar-12.0.0",
   "action" : "enable"
 }, {
   "id" : "mod-configuration-5.12.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@folio/acquisition-units": "6.0.0",
     "@folio/agreements": "12.0.1",
     "@folio/bulk-edit": "5.0.0",
-    "@folio/calendar": "11.0.3",
+    "@folio/calendar": "12.0.0",
     "@folio/checkin": "11.0.0",
     "@folio/checkout": "12.0.0",
     "@folio/circulation": "11.0.0",

--- a/stripes-install.json
+++ b/stripes-install.json
@@ -12,7 +12,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_calendar-11.0.3",
+    "id": "folio_calendar-12.0.0",
     "action": "enable"
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,10 +1385,10 @@
     uuid "^9.0.0"
     yup "^1.4.0"
 
-"@folio/calendar@11.0.3":
-  version "11.0.3"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/calendar/-/calendar-11.0.3.tgz#39fc5cea6721628044e5ac8a92bb109cec84856c"
-  integrity sha512-0zDiBxXBYBa8LM417uDI8ZJuTRx5zqTZNnLw7KjNGGys0dimyMmch3z8DR/qMVdJy6C7/b2VyLG4lvUxBY17gg==
+"@folio/calendar@12.0.0":
+  version "12.0.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/calendar/-/calendar-12.0.0.tgz#ed8c6201244edb227cf99f7aeda3bc6b273c8fbb"
+  integrity sha512-FEMu5yrPaRWX2EpzbTwiGdQ4SVVLc8LKg2uOWcqNx6Z+NFVoUjUAiLH3+nlxP52IbTIMYnv7iie+e2d1Bxv2oQ==
   dependencies:
     "@types/memoizee" "^0.4.8"
     "@types/react-router-dom" "^5.2.0"


### PR DESCRIPTION
ui-calendar v12.0.0 (Sunflower) released https://github.com/folio-org/ui-calendar/releases/tag/v12.0.0
https://open-libr-foundation.slack.com/archives/CGPMHLX9B/p1743597459352799
