### PR TITLE
Include ui-mosaic-settings in the platform-complete

### DIFF
--- a/eureka-tpl/stripes.config.js
+++ b/eureka-tpl/stripes.config.js
@@ -52,6 +52,7 @@ module.exports = {
     '@folio/licenses' : {},
     '@folio/lists' : {},
     '@folio/local-kb-admin': {},
+    '@folio/mosaic-settings' : {},
     '@folio/myprofile' : {},
     '@folio/notes' : {},
     '@folio/oa' : {},

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@folio/lists": ">=1.2.0",
     "@folio/local-kb-admin": ">=1.0.0",
     "@folio/marc-authorities": ">=1.0.0",
+    "@folio/mosaic-settings": ">=1.0.0",
     "@folio/myprofile": ">=1.1.0",
     "@folio/notes": ">=1.0.0",
     "@folio/oa": ">=1.0.0",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -57,6 +57,7 @@ module.exports = {
     '@folio/developer' : {},
     '@folio/handler-stripes-registry': {},
     "@folio/gobi-settings": {},
+    '@folio/mosaic-settings' : {},
     '@folio/myprofile' : {},
     '@folio/notes' : {},
     '@folio/oai-pmh' : {},


### PR DESCRIPTION
A new app `ui-mosaic-settings` has been created ([UIMS-2](https://folio-org.atlassian.net/browse/UIMS-2)) and should be included in platform apps.