### PR TITLE
build: change stripes-erm-components dep for snapshot to >=

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@folio/stripes": "^10.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
     "@folio/stripes-build": "^1.0.0",
-    "@folio/stripes-erm-components": "^9.0.0",
+    "@folio/stripes-erm-components": ">=9.0.0",
     "@folio/stripes-inventory-components": ">=1.0.0",
     "@folio/stripes-marc-components": ">=1.0.0",
     "@folio/tags": ">=1.1.0",


### PR DESCRIPTION
This was missed in the Sunflower changes, stripes-erm-components was moved to v10.0.x.

This is a bit of a grey area to me as to who is responsible for keeping this up to date. The last bump was performed by @zburke and the one before that was me.

 I see that `stripes-authority-components`, `stripes-inventory-components`, and `stripes-marc-components` are set up to use `>=` for snapshot, and so I'd like to mirror that here and avoid the dance needing to happen every time a major bump occurs.

Of course the expectation is that major releases will be announced in the `#folio-releases` channel and end up in the bugfest/release environments as before