### PR TITLE
Revert to pulling in latest ui-agreements now dependency has been fixed

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -72,10 +72,6 @@
     "action": "enable"
   },
   {
-    "id": "folio_agreements-12.1.109900000000735",
-    "action": "enable"
-  },
-  {
     "id": "mod-circulation-bff",
     "action": "enable"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@folio/acquisition-units": ">=1.0.0",
-    "@folio/agreements": "12.1.109900000000735",
+    "@folio/agreements": ">=2.0.0",
     "@folio/bulk-edit": ">=1.0.0",
     "@folio/calendar": ">=2.0.5",
     "@folio/checkin": ">=1.3.0",


### PR DESCRIPTION
ui-agreements was [previously pinned](https://github.com/folio-org/platform-complete/pull/3429) as [a dependency was accidentally declared as a devDependency](https://github.com/folio-org/ui-agreements/pull/1427), causing the build to fail.


This has since [been rectified](https://github.com/folio-org/ui-agreements/pull/1429)