### PR TITLE
Revert "FOLIO-4392 pass `--lazy` in `build` for code-splitting"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for platform-complete
 
-# 2026-R1, Trillium
-
-* Build with `--lazy` to leverage code-splitting. Refs FOLIO-4392.
-
 # 2025-R1, Sunflower
 
 * Bump `react-intl` to `^7`. Refs STRIPES-960 (and FOLIO-4262, FOLIO-4263).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0-SNAPSHOT",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "export NODE_OPTIONS=\"--max-old-space-size=8000 $NODE_OPTIONS\"; stripes-build build stripes.config.js --lazy",
+    "build": "export NODE_OPTIONS=\"--max-old-space-size=8000 $NODE_OPTIONS\"; stripes-build build stripes.config.js",
     "start": "stripes serve stripes.config.js",
     "build-module-descriptors": "stripes-build mod descriptor stripes.config.js --full --strict  --output ./ModuleDescriptors",
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",


### PR DESCRIPTION
Reverts folio-org/platform-complete#3497

Once again, revert FOLIO-4392. The original PR #3485, was reverted in PR #3496 to due to problems with how `getModule()` was implemented in stripes-webpack. We then restored it in #3497 but are reverting it this time due to a collection of CSS bugs ([STCOM-1487](https://folio-org.atlassian.net/browse/STCOM-1487), [UIPFI-189](https://folio-org.atlassian.net/browse/UIPFI-189), and [STCOM-1476](https://folio-org.atlassian.net/browse/STCOM-1476)), now commonly understood to have a root-cause in stripes-webpack ([STRWEB-147](https://folio-org.atlassian.net/browse/STRWEB-147)) where code-splitting causes some styles to be repeated and others to be re-ordered. h/t @BogdanDenis for detailing the problem in https://github.com/folio-org/ui-plugin-find-instance/pull/304. 