### PR TITLE
FOLIO-4478: Bump picomatch 2.3.1 -> 2.3.2 fixing ReDoS CVE-2026-33671

### DIFF
--- a/install.json
+++ b/install.json
@@ -296,13 +296,13 @@
   "id" : "mod-marc-migrations-2.0.5",
   "action" : "enable"
 }, {
-  "id" : "mod-reading-room-1.2.1",
+  "id" : "mod-reading-room-2.0.0",
   "action" : "enable"
 }, {
   "id" : "folio_reading-room-2.0.1",
   "action" : "enable"
 }, {
-  "id" : "mod-record-specifications-2.0.3",
+  "id" : "mod-record-specifications-3.0.0",
   "action" : "enable"
 }, {
   "id" : "mod-quick-marc-7.0.0",
@@ -320,7 +320,7 @@
   "id" : "folio_ld-folio-wrapper-1.3.4",
   "action" : "enable"
 }, {
-  "id" : "mod-batch-print-1.3.0",
+  "id" : "mod-batch-print-1.4.0",
   "action" : "enable"
 }, {
   "id" : "mod-sender-1.14.2",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -204,11 +204,11 @@
     "action": "enable"
   },
   {
-    "id": "mod-reading-room-1.2.1",
+    "id": "mod-reading-room-2.0.0",
     "action": "enable"
   },
   {
-    "id": "mod-record-specifications-2.0.3",
+    "id": "mod-record-specifications-3.0.0",
     "action": "enable"
   },
   {
@@ -220,7 +220,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-batch-print-1.3.0",
+    "id": "mod-batch-print-1.4.0",
     "action": "enable"
   },
   {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
+    "picomatch": "^2.3.2",
     "qs": "^6.14.1",
     "redux-form": "^8.0.0",
     "typescript": "~5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6995,10 +6995,10 @@ picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.3.1, picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4478

Bump in the Sunflower branch R1-2025

This fixes ReDos CVE-2026-33671 = https://github.com/advisories/GHSA-c2c7-rcm5-vvqj