### PR TITLE
FOLIO-4479: Bump brace-expansion 1.1.11 -> 1.1.13 fix CVE-2026-33750

### DIFF
--- a/install.json
+++ b/install.json
@@ -296,13 +296,13 @@
   "id" : "mod-marc-migrations-2.0.5",
   "action" : "enable"
 }, {
-  "id" : "mod-reading-room-1.2.1",
+  "id" : "mod-reading-room-2.0.0",
   "action" : "enable"
 }, {
   "id" : "folio_reading-room-2.0.1",
   "action" : "enable"
 }, {
-  "id" : "mod-record-specifications-2.0.3",
+  "id" : "mod-record-specifications-3.0.0",
   "action" : "enable"
 }, {
   "id" : "mod-quick-marc-7.0.0",
@@ -320,7 +320,7 @@
   "id" : "folio_ld-folio-wrapper-1.3.4",
   "action" : "enable"
 }, {
-  "id" : "mod-batch-print-1.3.0",
+  "id" : "mod-batch-print-1.4.0",
   "action" : "enable"
 }, {
   "id" : "mod-sender-1.14.2",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -204,11 +204,11 @@
     "action": "enable"
   },
   {
-    "id": "mod-reading-room-1.2.1",
+    "id": "mod-reading-room-2.0.0",
     "action": "enable"
   },
   {
-    "id": "mod-record-specifications-2.0.3",
+    "id": "mod-record-specifications-3.0.0",
     "action": "enable"
   },
   {
@@ -220,7 +220,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-batch-print-1.3.0",
+    "id": "mod-batch-print-1.4.0",
     "action": "enable"
   },
   {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@rehooks/local-storage": "2.4.5",
     "@folio/stripes-acq-components": "7.0.5",
     "@folio/stripes-authorization-components": "2.0.8",
+    "brace-expansion": "^1.1.13",
     "colors": "1.4.0",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,10 +3862,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^1.1.13, brace-expansion@^1.1.7:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
+  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4479

In the Sunflower branch R1-2025 upgrade brace-expansion from 1.1.11 -> 1.1.13.

This fixes infinite loop security vulnerability CVE-2026-33750: https://github.com/advisories/GHSA-f886-m6hf-6m8v