### PR TITLE
FOLIO-4481: Bump handlebars 4.7.8 -> 4.7.9 fix Injection CVE-2026-33941

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@folio/stripes-authorization-components": "2.0.8",
     "colors": "1.4.0",
     "final-form": "^4.20.4",
+    "handlebars": "^4.7.9",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
     "qs": "^6.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,10 +5611,10 @@ handlebars-loader@^1.7.1:
     loader-utils "1.4.x"
     object-assign "^4.1.0"
 
-handlebars@^4.7.7:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@^4.7.7, handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4481

Sunflower R1-2025

Upgrade handlebars from 4.7.8 to 4.7.9.

This fixed the Code Injection vulnerability: CVE-2026-33941 – https://github.com/advisories/GHSA-xjpj-3mr7-gcpf