### PR TITLE
FOLIO-4474: R1-2025: dompurify ^3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@folio/stripes-acq-components": "7.0.5",
     "@folio/stripes-authorization-components": "2.0.8",
     "colors": "1.4.0",
+    "dompurify": "^3.3.3",
     "final-form": "^4.20.4",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4716,17 +4716,10 @@ domhandler@^5.0, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^3.0.9, dompurify@^3.1.3, dompurify@^3.2.0:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.3.tgz#05dd2175225324daabfca6603055a09b2382a4cd"
-  integrity sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==
-  optionalDependencies:
-    "@types/trusted-types" "^2.0.7"
-
-dompurify@^3.2.4:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
-  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
+dompurify@^3.0.9, dompurify@^3.1.3, dompurify@^3.2.0, dompurify@^3.2.4, dompurify@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.3.tgz#680cae8af3e61320ddf3666a3bc843f7b291b2b6"
+  integrity sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4474

Bump dompurify from 3.2.3/3.2.6 to 3.3.3.

This fixes several security vulnerabilities:

* https://github.com/cure53/DOMPurify/security/advisories/GHSA-cj63-jhhr-wcxv USE_PROFILES prototype pollution allows event handlers
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-cjmm-f4jc-qw8r ADD_ATTR predicate skips URI validation
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-9p3w-6h5p-cv75 XSS via ADD_ATTR/ADD_TAGS Function Predicate State Leakage Across sanitize() Calls
* https://github.com/cure53/DOMPurify/security/advisories/GHSA-4w3q-35jp-p934 IN_PLACE mode fails to sanitize cross-window DOM elements, allowing XSS bypass