### PR TITLE
FOLIO-4486 bump UI build tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for platform-complete
 
+# 2026-R1 Trillium
+
+* Bump `@folio/stripes-cli` to `^5`, `@folio/stripes-build` to `^2`. Refs FOLIO-4486.
+
 # 2025-R1, Sunflower
 
 * Bump `react-intl` to `^7`. Refs STRIPES-960 (and FOLIO-4262, FOLIO-4263).

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@folio/servicepoints": ">=1.1.0",
     "@folio/stripes": "^10.0.0",
     "@folio/stripes-authority-components": ">=2.0.0",
-    "@folio/stripes-build": "^1.0.0",
+    "@folio/stripes-build": "^2.0.0",
     "@folio/stripes-erm-components": ">=9.0.0",
     "@folio/stripes-inventory-components": ">=1.0.0",
     "@folio/stripes-marc-components": ">=1.0.0",
@@ -104,7 +104,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@folio/stripes-cli": "^4.0.0"
+    "@folio/stripes-cli": "^5.0.0"
   },
   "resolutions": {
     "typescript": "~5.5",


### PR DESCRIPTION
* Bump `@folio/stripes-cli` to `^5`, `@folio/stripes-build` to `^2`. These releases incorporate `@folio/stripes-webpack` `v7`, where [STRWEB-148](https://folio-org.atlassian.net/browse/STRWEB-148) has been patched.

Refs [FOLIO-4486](https://folio-org.atlassian.net/browse/FOLIO-4486)