### PR TITLE
FOLIO-4479: Bump brace-expansion 1.1.11 -> 1.1.13 fix CVE-2026-33750

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@rehooks/local-storage": "2.4.5",
     "@folio/stripes-acq-components": "7.0.5",
     "@folio/stripes-authorization-components": "2.0.8",
+    "brace-expansion": "^1.1.13",
     "colors": "1.4.0",
     "dompurify": "^3.2.7",
     "final-form": "^4.20.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,10 +3752,10 @@ boxen@^7.0.0:
     widest-line "^4.0.1"
     wrap-ansi "^8.1.0"
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@^1.1.13, brace-expansion@^1.1.7:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
+  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4479

In the Sunflower branch R1-2025 upgrade brace-expansion from 1.1.11 -> 1.1.13.

This fixes infinite loop security vulnerability CVE-2026-33750: https://github.com/advisories/GHSA-f886-m6hf-6m8v

(cherry picked from commit 5d54949419e9184186aff531c3fcefd692e5c9c3)