### PR TITLE
UILD-746: ld-folio-wrapper 1.3.4, ui-linked-data 1.0.6 fixing vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@folio/handler-stripes-registry": "3.0.0",
     "@folio/inventory": "13.0.12",
     "@folio/invoice": "7.0.5",
-    "@folio/ld-folio-wrapper": "1.3.3",
+    "@folio/ld-folio-wrapper": "1.3.4",
     "@folio/ldp": "3.1.2",
     "@folio/licenses": "12.0.1",
     "@folio/lists": "4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,12 +1765,12 @@
     "@folio/plugin-find-organization" "^6.0.0"
     "@folio/plugin-find-po-line" "^6.0.0"
 
-"@folio/ld-folio-wrapper@1.3.3":
-  version "1.3.3"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/ld-folio-wrapper/-/ld-folio-wrapper-1.3.3.tgz#e065c6f89ce11d663a75cbf2650542254312744e"
-  integrity sha512-hgMyj0ZMA1zFZoKbE077KGwT0P1fHtVbrS3nrWZ1I1k1rUETiEc+yJfA5AdTwGgIDCJ/unN4vAeQKVzulez4dQ==
+"@folio/ld-folio-wrapper@1.3.4":
+  version "1.3.4"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/ld-folio-wrapper/-/ld-folio-wrapper-1.3.4.tgz#fe8d0a2a36593f97c2bc274b5a361b433ef0ae94"
+  integrity sha512-9/4RhHdWSm01s8/3GaLpZLsylLUDMEsfZg+/GY38pviMP1InzE6MKDjnhytWSyylvhG0eeqNwV/+RZ7mHmIIXw==
   dependencies:
-    "@folio/linked-data" "^1.0.5"
+    "@folio/linked-data" "^1.0.6"
     prop-types "^15.6.0"
 
 "@folio/ldp@3.1.2":
@@ -1813,9 +1813,9 @@
     react-final-form-arrays "^3.1.0"
     react-router-prop-types "^1.0.4"
 
-"@folio/linked-data@^1.0.5":
-  version "1.0.5"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/linked-data/-/linked-data-1.0.5.tgz#62054da5a6b8b2883c17836c7bfdcbadc4120e31"
+"@folio/linked-data@^1.0.6":
+  version "1.0.6"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/linked-data/-/linked-data-1.0.6.tgz#431d860604f7d35fe314c60426d61e09872f4d72"
   integrity sha512-W879IM908PJGfGsv55vd6lLTBZiDpuonxwx4rWJO/2nl4Ik0D2uTUOkU1KAQYnPWM9WXjUEE2MfjPf7Nzga+Lw==
   dependencies:
     classnames "^2.5.1"
@@ -1823,7 +1823,7 @@
     react "^18.3.1"
     react-dom "^18.3.1"
     react-intl "^6.8.9"
-    react-router-dom "^6.28.1"
+    react-router-dom "^6.30.3"
     react-select "^5.9.0"
     uuid "^9.0.1"
     zustand "^5.0.3"
@@ -2997,10 +2997,10 @@
   resolved "https://registry.yarnpkg.com/@rehooks/local-storage/-/local-storage-2.4.5.tgz#92c773ce623e168274557499679582cd32749f77"
   integrity sha512-3Q4KtiUBaKoIDRK72BWfAy50ul6hbw29f/M7tyCzlMe2FbSsiQNok0WGeBLaYj4T2PJ7JMSJlSbUGY8RNsImmw==
 
-"@remix-run/router@1.23.0":
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.0.tgz#35390d0e7779626c026b11376da6789eb8389242"
-  integrity sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==
+"@remix-run/router@1.23.2":
+  version "1.23.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
+  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
 
 "@sindresorhus/is@^5.2.0":
   version "5.6.0"
@@ -7508,13 +7508,13 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router-dom@^6.28.1:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.0.tgz#a64774104508bff56b1affc2796daa3f7e76b7df"
-  integrity sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==
+react-router-dom@^6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
+  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
   dependencies:
-    "@remix-run/router" "1.23.0"
-    react-router "6.30.0"
+    "@remix-run/router" "1.23.2"
+    react-router "6.30.3"
 
 react-router-prop-types@^1.0.4:
   version "1.0.5"
@@ -7539,12 +7539,12 @@ react-router@5.3.4, react-router@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.30.0:
-  version "6.30.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.0.tgz#9789d775e63bc0df60f39ced77c8c41f1e01ff90"
-  integrity sha512-D3X8FyH9nBcTSHGdEKurK7r8OYE1kKFn3d/CF+CoxbSHkxU7o37+Uh7eAHRXr6k2tSExXYO++07PeXJtA/dEhQ==
+react-router@6.30.3:
+  version "6.30.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
+  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
   dependencies:
-    "@remix-run/router" "1.23.0"
+    "@remix-run/router" "1.23.2"
 
 react-select@^5.9.0:
   version "5.10.1"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UILD-746

Bump ld-folio-wrapper from 1.3.3 to 1.3.4.

This transitively bumps
* linked-data from ^1.0.5 to ^1.0.6
* react-router-dom from ^6.28.1 to ^6.30.3
* @remix-run/router from 1.23.0 to 1.23.2
* react-router from 6.30.0 to 6.30.3

This fixes security vulnerabilities:
* CVE-2025-68470 - https://github.com/advisories/GHSA-9jcx-v3wj-wh4m - react-router-dom - open redirect
* CVE-2026-22029 - https://github.com/advisories/GHSA-2w69-qvjg-hvjx - @remix-run/router - Cross-site Scripting (XSS)