### PR TITLE
[R1-2025-okapi] Bump mod-login-saml from 2.10.1 to 2.10.4

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -156,7 +156,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-login-saml-2.10.1",
+    "id": "mod-login-saml-2.10.4",
     "action": "enable"
   },
   {

--- a/install.json
+++ b/install.json
@@ -179,7 +179,7 @@
   "id" : "mod-orders-storage-13.9.7",
   "action" : "enable"
 }, {
-  "id" : "mod-login-saml-2.10.1",
+  "id" : "mod-login-saml-2.10.4",
   "action" : "enable"
 }, {
   "id" : "mod-oai-pmh-3.15.4",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -120,7 +120,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-login-saml-2.10.1",
+    "id": "mod-login-saml-2.10.4",
     "action": "enable"
   },
   {


### PR DESCRIPTION
See releases for fixed security vulnerabilities:
https://github.com/folio-org/mod-login-saml/releases