### PR TITLE
FOLIO-4481: Bump handlebars 4.7.8 -> 4.7.9 fix Injection CVE-2026-33941

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6335,10 +6335,10 @@ handlebars-loader@^1.7.1:
     loader-utils "1.4.x"
     object-assign "^4.1.0"
 
-handlebars@^4.7.7:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@^4.7.7, handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4481

Sunflower R1-2025

Upgrade handlebars from 4.7.8 to 4.7.9.

This fixed the Code Injection vulnerability: CVE-2026-33941 – GHSA-xjpj-3mr7-gcpf

See also #3584, which implements the same change for the `R1-2025` branch.