### PR TITLE
chore(docker): upgrade Node.js base image from 18 to 22

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine as stripes_build
+FROM node:22-alpine as stripes_build
 
 ARG CXXFLAGS="-std=c++17"
 


### PR DESCRIPTION
Node 18 has been out of support since 2025-04-30:
https://github.com/nodejs/Release#end-of-life-releases

Latests versions (with security fixed) of some js packages require a more recent node version than 18.