### PR TITLE
RANCHER-3128: "yarn install" with "--ignore-scripts --non-interactive"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apk upgrade \
 RUN yarn config set python /usr/bin/python3
 
 RUN yarn config set @folio:registry https://repository.folio.org/repository/npm-folio/
-RUN yarn install
+RUN yarn install --ignore-scripts --non-interactive
 RUN yarn build-module-descriptors
 ARG OKAPI_URL=http://localhost:9130
 ARG TENANT_ID=diku


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RANCHER-3128

See https://folio-org.atlassian.net/browse/FOLIO-4492

Back-port this commit to R1-2025-okapi:
https://github.com/folio-org/platform-lsp/commit/3b441893edcfe7e04e3c9f8c0c2d819881a61610