### PR TITLE
lock webpack to ~5.107.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "qs": "^6.14.1",
     "redux-form": "^8.0.0",
     "typescript": "~5.5",
+    "webpack": "~5.107.2",
     "@types/react": "^18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10229,7 +10229,7 @@ webpack-virtual-modules@^0.4.3:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.6.tgz#3e4008230731f1db078d9cb6f68baf8571182b45"
   integrity sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==
 
-webpack@^5.104.1:
+webpack@^5.104.1, webpack@~5.107.2:
   version "5.107.2"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.107.2.tgz#dea14dcb177b46b29de15f952f7303691ee2b596"
   integrity sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==


### PR DESCRIPTION
port https://github.com/folio-org/platform-lsp/pull/202/changes from platform-lsp R1-2025 to platform-complete R1-2025-okapi

Description copied from the platform-lsp PR:

Breaking changes in webpack 5.110.0 cause build failures due to issue https://github.com/webpack/webpack/issues/21844:
```
11:28:15  HookWebpackError: Transform failed with 1 error:
11:28:15  /etc/folio/stripes/node_modules/esbuild/lib/main.js:534:29: ERROR: "minify" must be a boolean
11:28:15      at makeWebpackError (/etc/folio/stripes/node_modules/webpack/lib/errors/HookWebpackError.js:76:9)
...
```
Given `yarn.lock` currently includes `5.107.2`, adding the same value as a resolution in `package.json` may seem odd but in fact this change will have the fewest side-effects for folks who are building from this branch without the `--frozen-lockfile` flag.

Refs [FOLIO-4563](https://folio-org.atlassian.net/browse/FOLIO-4563)